### PR TITLE
Display track progress for Spotify playback

### DIFF
--- a/SonosControl.DAL/Interfaces/ISonosConnectorRepo.cs
+++ b/SonosControl.DAL/Interfaces/ISonosConnectorRepo.cs
@@ -9,6 +9,7 @@ namespace SonosControl.DAL.Interfaces
         Task StartPlaying(string ip);
         Task StopPlaying(string ip);
         Task<string> GetCurrentTrackAsync(string ip);
+        Task<(TimeSpan Position, TimeSpan Duration)> GetTrackProgressAsync(string ip);
         Task SetTuneInStationAsync(string ip, string stationUri);
         Task<string> GetCurrentStationAsync(string ip);
         Task<string?> SearchSpotifyTrackAsync(string query, string accessToken);

--- a/SonosControl.DAL/Repos/SonosConnectorRepo.cs
+++ b/SonosControl.DAL/Repos/SonosConnectorRepo.cs
@@ -229,6 +229,47 @@ namespace SonosControl.DAL.Repos
             }
         }
 
+        public async Task<(TimeSpan Position, TimeSpan Duration)> GetTrackProgressAsync(string ip)
+        {
+            using var client = new HttpClient();
+
+            try
+            {
+                var url = $"http://{ip}:1400/MediaRenderer/AVTransport/Control";
+
+                var content = new StringContent(
+                    @"<?xml version=\"1.0\" encoding=\"utf-8\"?>
+            <s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"
+                        s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
+                <s:Body>
+                    <u:GetPositionInfo xmlns:u=\"urn:schemas-upnp-org:service:AVTransport:1\">
+                        <InstanceID>0</InstanceID>
+                    </u:GetPositionInfo>
+                </s:Body>
+            </s:Envelope>", Encoding.UTF8, "text/xml");
+
+                content.Headers.ContentType = MediaTypeHeaderValue.Parse("text/xml; charset=utf-8");
+                content.Headers.Add("SOAPACTION", "\"urn:schemas-upnp-org:service:AVTransport:1#GetPositionInfo\"");
+
+                var response = await client.PostAsync(url, content);
+                response.EnsureSuccessStatusCode();
+
+                var xml = await response.Content.ReadAsStringAsync();
+
+                var doc = new XmlDocument();
+                doc.LoadXml(xml);
+
+                TimeSpan.TryParse(doc.GetElementsByTagName("RelTime").Item(0)?.InnerText ?? "00:00:00", out var relTime);
+                TimeSpan.TryParse(doc.GetElementsByTagName("TrackDuration").Item(0)?.InnerText ?? "00:00:00", out var trackDuration);
+
+                return (relTime, trackDuration);
+            }
+            catch
+            {
+                return (TimeSpan.Zero, TimeSpan.Zero);
+            }
+        }
+
 
         public async Task<string> GetCurrentStationAsync(string ip)
         {

--- a/SonosControl.Web/Pages/Index.razor
+++ b/SonosControl.Web/Pages/Index.razor
@@ -70,6 +70,12 @@
                             <p class="mb-0 text-light-emphasis currently-playing-text text-break">
                                 <strong>Track:</strong> @currentlyPlaying
                             </p>
+                            @if (!string.IsNullOrWhiteSpace(trackProgress))
+                            {
+                                <p class="mb-0 text-light-emphasis currently-playing-text text-break">
+                                    <strong>Time:</strong> @trackProgress
+                                </p>
+                            }
                         </div>
                     </div>
                 </div>
@@ -266,6 +272,7 @@
 
     private string currentlyPlaying = "Loading...";
     private string currentyPlayingDisplay = "Loading...";
+    private string trackProgress = "";
     private Timer? _stationUpdateTimer;
     private string? addStationErrorMessage;
     private string? addTrackErrorMessage;
@@ -313,6 +320,8 @@
             }
 
             currentlyPlaying = await _uow.ISonosConnectorRepo.GetCurrentTrackAsync(_settings.IP_Adress);
+            var progress = await _uow.ISonosConnectorRepo.GetTrackProgressAsync(_settings.IP_Adress);
+            trackProgress = $"{progress.Position:mm\\:ss} / {progress.Duration:mm\\:ss}";
 
             await InvokeAsync(StateHasChanged);
         }


### PR DESCRIPTION
## Summary
- Add `GetTrackProgressAsync` to Sonos connector interface and implementation to retrieve current position and duration
- Surface track progress in the web UI's Now Playing card

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6895b336a2908321b84532e0a3ba9b95