### PR TITLE
Add confirmation dialogs for deletions

### DIFF
--- a/SonosControl.Web/Pages/Index.razor
+++ b/SonosControl.Web/Pages/Index.razor
@@ -4,6 +4,7 @@
 @inject ApplicationDbContext Db
 @using SonosControl.Web.Models;
 @inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IJSRuntime JS
 @attribute [Authorize(Roles = "admin,operator")]
 
 <PageTitle>Sonos Control</PageTitle>
@@ -527,6 +528,9 @@
     {
         if (_settings == null) return;
 
+        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Are you sure you want to delete station '{station.Name}'?");
+        if (!confirmed) return;
+
         _settings.Stations?.Remove(station);
         await SaveSettings();
 
@@ -537,6 +541,9 @@
     // Remove Spotify track
     private async Task RemoveSpotifyTrack(SpotifyObject track)
     {
+        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Are you sure you want to delete track '{track.Name}'?");
+        if (!confirmed) return;
+
         _settings.SpotifyTracks.Remove(track);
         // You may also want to save the settings after removing it
         Console.WriteLine($"Removed track: {track.Name}");

--- a/SonosControl.Web/Pages/UserManagement.razor
+++ b/SonosControl.Web/Pages/UserManagement.razor
@@ -8,6 +8,7 @@
 @using SonosControl.Web.Data
 @inject ApplicationDbContext Db
 @using SonosControl.Web.Models;
+@inject IJSRuntime JS
 
 <PageTitle>User Management</PageTitle>
 
@@ -148,6 +149,9 @@
             errorMessage = "You cannot delete your own user account.";
             return;
         }
+
+        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Are you sure you want to delete user '{user.UserName}'?");
+        if (!confirmed) return;
 
         var result = await UserManager.DeleteAsync(user);
         if (result.Succeeded)


### PR DESCRIPTION
## Summary
- Prompt before deleting users in admin UI
- Confirm removing TuneIn stations and Spotify tracks on main page

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba99868f148321ba087cc15291edff