### PR TITLE
Refresh roles on page reload

### DIFF
--- a/SonosControl.Web/Program.cs
+++ b/SonosControl.Web/Program.cs
@@ -1,6 +1,7 @@
 using SonosControl.DAL.Interfaces;
 using SonosControl.DAL.Repos;
 using SonosControl.Web.Services;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -19,6 +20,7 @@ builder.Services.AddHostedService<SonosControlService>();
 builder.Services.AddSingleton<SonosControlService>();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<ActionLogger>();
+builder.Services.AddScoped<IClaimsTransformation, RoleClaimsTransformation>();
 
 builder.Services.AddLocalization();
 builder.Services.AddControllersWithViews();

--- a/SonosControl.Web/Services/RoleClaimsTransformation.cs
+++ b/SonosControl.Web/Services/RoleClaimsTransformation.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using System.Security.Claims;
+using SonosControl.Web.Models;
+
+namespace SonosControl.Web.Services;
+
+/// <summary>
+/// Refreshes role claims for authenticated users on each request so that
+/// role changes are reflected after a simple page refresh instead of
+/// requiring a full re-login.
+/// </summary>
+public class RoleClaimsTransformation : IClaimsTransformation
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public RoleClaimsTransformation(UserManager<ApplicationUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+    {
+        var identity = principal.Identity as ClaimsIdentity;
+        if (identity?.IsAuthenticated != true)
+            return principal;
+
+        var user = await _userManager.GetUserAsync(principal);
+        if (user == null)
+            return principal;
+
+        // Remove existing role claims and reload from database
+        foreach (var claim in identity.FindAll(identity.RoleClaimType).ToList())
+        {
+            identity.RemoveClaim(claim);
+        }
+
+        var roles = await _userManager.GetRolesAsync(user);
+        foreach (var role in roles)
+        {
+            identity.AddClaim(new Claim(identity.RoleClaimType, role));
+        }
+
+        return principal;
+    }
+}
+


### PR DESCRIPTION
## Summary
- refresh user role claims from the database on each request via a new `RoleClaimsTransformation`
- register the transformation so role changes apply after a page refresh, avoiding full relogin

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bec807e6d4832199a927a76a124bd8