### PR TITLE
fix: correct GetTrackProgress SOAP string

### DIFF
--- a/SonosControl.DAL/Repos/SonosConnectorRepo.cs
+++ b/SonosControl.DAL/Repos/SonosConnectorRepo.cs
@@ -238,11 +238,11 @@ namespace SonosControl.DAL.Repos
                 var url = $"http://{ip}:1400/MediaRenderer/AVTransport/Control";
 
                 var content = new StringContent(
-                    @"<?xml version=\"1.0\" encoding=\"utf-8\"?>
-            <s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"
-                        s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+            <s:Envelope xmlns:s=""http://schemas.xmlsoap.org/soap/envelope/""
+                        s:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
                 <s:Body>
-                    <u:GetPositionInfo xmlns:u=\"urn:schemas-upnp-org:service:AVTransport:1\">
+                    <u:GetPositionInfo xmlns:u=""urn:schemas-upnp-org:service:AVTransport:1"">
                         <InstanceID>0</InstanceID>
                     </u:GetPositionInfo>
                 </s:Body>


### PR DESCRIPTION
## Summary
- fix SOAP request XML string in GetTrackProgressAsync

## Testing
- `dotnet build SonosControl.Web/SonosControl.Web.csproj -c Release` *(fails: dotnet: command not found)*
- `dotnet test` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed1a743fc8321a389ba70bdb48c58