### PR TITLE
Handle zero duration track progress

### DIFF
--- a/SonosControl.Web/Pages/Index.razor
+++ b/SonosControl.Web/Pages/Index.razor
@@ -322,7 +322,17 @@
 
             currentlyPlaying = await _uow.ISonosConnectorRepo.GetCurrentTrackAsync(_settings.IP_Adress);
             var progress = await _uow.ISonosConnectorRepo.GetTrackProgressAsync(_settings.IP_Adress);
-            trackProgress = $"{progress.Position:mm\\:ss} / {progress.Duration:mm\\:ss}";
+
+            if (progress.Duration == TimeSpan.Zero)
+            {
+                trackProgress = progress.Position == TimeSpan.Zero
+                    ? string.Empty
+                    : $"{progress.Position:mm\\:ss}";
+            }
+            else
+            {
+                trackProgress = $"{progress.Position:mm\\:ss} / {progress.Duration:mm\\:ss}";
+            }
 
             await InvokeAsync(StateHasChanged);
         }


### PR DESCRIPTION
## Summary
- avoid layout shifts by suppressing track progress when both times are zero
- show only relative time if duration is not reported

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden while attempting to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bed4b000a48321925c39d1838c0c02