### PR TITLE
Add superadmin role and tighten permission management

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ password:
 ESPmtZ7&LW2z&xHF
 ```
 
+The default user is seeded with both **admin** and **superadmin** roles. Only a superadmin can assign roles to other users, and superadmin accounts cannot be deleted by non-superadmin users.
+
 ### *This is optional. You only have to do this if you get a config.json error for some reason.*
 
 At first create a folder called **Data**.

--- a/SonosControl.Web/Data/DataSeeder.cs
+++ b/SonosControl.Web/Data/DataSeeder.cs
@@ -8,7 +8,7 @@ public static class DataSeeder
         var userManager = serviceProvider.GetRequiredService<UserManager<ApplicationUser>>();
         var roleManager = serviceProvider.GetRequiredService<RoleManager<IdentityRole>>();
 
-        string[] roles = { "admin", "operator" };
+        string[] roles = { "superadmin", "admin", "operator" };
 
         // Ensure all roles exist
         foreach (var role in roles)
@@ -42,10 +42,15 @@ public static class DataSeeder
             }
         }
 
-        // Ensure user is in admin role
+        // Ensure user is in admin and superadmin roles
         if (!await userManager.IsInRoleAsync(adminUser, "admin"))
         {
             await userManager.AddToRoleAsync(adminUser, "admin");
+        }
+
+        if (!await userManager.IsInRoleAsync(adminUser, "superadmin"))
+        {
+            await userManager.AddToRoleAsync(adminUser, "superadmin");
         }
     }
 }

--- a/SonosControl.Web/Pages/ConfigPage.razor
+++ b/SonosControl.Web/Pages/ConfigPage.razor
@@ -4,7 +4,7 @@
 @inject ApplicationDbContext Db
 @using SonosControl.Web.Models;
 
-<AuthorizeView Roles="admin,operator">
+<AuthorizeView Roles="admin,operator,superadmin">
     <Authorized>
         @if (_settings is null)
         {
@@ -20,7 +20,8 @@
                     <input type="text" class="form-control bg-secondary text-light border-0"
                            @bind-value="IP_Adress"
                            @bind-value:event="oninput"
-                           placeholder="Enter IP Address"/>
+                           placeholder="Enter IP Address"
+                           disabled="@(!canEditIp)"/>
                 </div>
 
                 <div class="mb-3">
@@ -149,7 +150,7 @@
     </Authorized>
     <NotAuthorized>
         <div class="alert alert-warning">
-            You must be logged in as an admin or operator to view this page.
+            You must be logged in as an admin, superadmin, or operator to view this page.
         </div>
     </NotAuthorized>
 </AuthorizeView>
@@ -158,6 +159,7 @@
     private SonosSettings? _settings;
     private TimeOnly TimeRightNow = TimeOnly.FromDateTime(DateTime.Now);
     private Dictionary<DayOfWeek, bool> DaySelection = new();
+    private bool canEditIp;
 
 
     protected override async Task OnInitializedAsync()
@@ -166,6 +168,7 @@
 
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         var user = authState.User;
+        canEditIp = user.IsInRole("admin") || user.IsInRole("superadmin");
 
         if (user.Identity?.IsAuthenticated ?? false)
         {
@@ -299,6 +302,9 @@
         get => _settings!.IP_Adress;
         set
         {
+            if (!canEditIp)
+                return;
+
             _settings!.IP_Adress = value;
             SaveSettings();
             AddLog("IP-Adress Changed", $"IP: {value}");

--- a/SonosControl.Web/Pages/Index.razor
+++ b/SonosControl.Web/Pages/Index.razor
@@ -5,10 +5,10 @@
 @using SonosControl.Web.Models;
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject IJSRuntime JS
-@attribute [Authorize(Roles = "admin,operator")]
+@attribute [Authorize(Roles = "admin,operator,superadmin")]
 
 <PageTitle>Sonos Control</PageTitle>
-<AuthorizeView Roles="admin,operator">
+<AuthorizeView Roles="admin,operator,superadmin">
     <Authorized>
         @if (_settings is not null)
         {
@@ -242,7 +242,7 @@
     </Authorized>
     <NotAuthorized>
         <div class="alert alert-warning">
-            You must be logged in as an admin or operator to view this page.
+            You must be logged in as an admin, superadmin, or operator to view this page.
         </div>
     </NotAuthorized>
 </AuthorizeView>

--- a/SonosControl.Web/Pages/Logs.razor
+++ b/SonosControl.Web/Pages/Logs.razor
@@ -7,7 +7,7 @@
 
 <PageTitle>System Logs</PageTitle>
 
-<AuthorizeView Roles="admin">
+<AuthorizeView Roles="admin,superadmin">
     <Authorized>
         <div class="container-fluid logs-container p-4 bg-dark text-light rounded-4 shadow mt-5">
             <h3 class="mb-4 border-bottom pb-2">📜 System Logs</h3>
@@ -79,7 +79,7 @@
     </Authorized>
     <NotAuthorized>
         <div class="alert alert-warning mt-4 container">
-            You must be an admin to view logs.
+            You must be an admin or superadmin to view logs.
         </div>
     </NotAuthorized>
 </AuthorizeView>

--- a/SonosControl.Web/Pages/StationLookup.razor
+++ b/SonosControl.Web/Pages/StationLookup.razor
@@ -6,7 +6,7 @@
 @inject ApplicationDbContext Db
 @using SonosControl.Web.Models;
 
-<AuthorizeView Roles="admin,operator">
+<AuthorizeView Roles="admin,operator,superadmin">
     <Authorized>
         <div class="container p-4 bg-dark text-light rounded-4 shadow mt-4" style="max-width: 600px;">
             <h4 class="text-center mb-4 border-bottom pb-2">📻 Station Lookup</h4>
@@ -70,7 +70,7 @@
     </Authorized>
     <NotAuthorized>
         <div class="alert alert-warning mt-4 container">
-            You must be logged in as an admin or operator to view this page.
+            You must be logged in as an admin, superadmin, or operator to view this page.
         </div>
     </NotAuthorized>
 </AuthorizeView>

--- a/SonosControl.Web/Pages/UserManagement.razor
+++ b/SonosControl.Web/Pages/UserManagement.razor
@@ -12,7 +12,7 @@
 
 <PageTitle>User Management</PageTitle>
 
-<AuthorizeView Roles="admin,operator">
+<AuthorizeView Roles="superadmin,admin,operator">
     <Authorized>
         <div class="container container-lg p-4 bg-dark text-light rounded-4 shadow">
             <h3 class="mb-4 border-bottom pb-2">👥 User Management</h3>
@@ -62,21 +62,30 @@
                                     <div class="d-flex flex-wrap justify-content-center gap-2">
                                         <button class="btn btn-sm btn-outline-danger"
                                                 @onclick="() => DeleteUser(user)"
-                                                disabled="@IsCurrentUser(user)">
+                                                disabled="@(IsCurrentUser(user) || (!isSuperAdmin && userRoles[user.Id].Contains("superadmin")))">
                                             Delete
                                         </button>
 
-                                        <button class="btn btn-sm btn-outline-primary"
-                                                @onclick='() => ToggleRole(user, "admin")'
-                                                disabled="@IsCurrentUser(user)">
-                                            @(userRoles[user.Id].Contains("admin") ? "−Admin" : "+Admin")
-                                        </button>
+                                        @if (isSuperAdmin)
+                                        {
+                                            <button class="btn btn-sm btn-outline-primary"
+                                                    @onclick='() => ToggleRole(user, "admin")'
+                                                    disabled="@IsCurrentUser(user)">
+                                                @(userRoles[user.Id].Contains("admin") ? "−Admin" : "+Admin")
+                                            </button>
 
-                                        <button class="btn btn-sm btn-outline-secondary"
-                                                @onclick='() => ToggleRole(user, "operator")'
-                                                disabled="@IsCurrentUser(user)">
-                                            @(userRoles[user.Id].Contains("operator") ? "−Operator" : "+Operator")
-                                        </button>
+                                            <button class="btn btn-sm btn-outline-secondary"
+                                                    @onclick='() => ToggleRole(user, "operator")'
+                                                    disabled="@IsCurrentUser(user)">
+                                                @(userRoles[user.Id].Contains("operator") ? "−Operator" : "+Operator")
+                                            </button>
+
+                                            <button class="btn btn-sm btn-outline-warning"
+                                                    @onclick='() => ToggleRole(user, "superadmin")'
+                                                    disabled="@IsCurrentUser(user)">
+                                                @(userRoles[user.Id].Contains("superadmin") ? "−Superuser" : "+Superuser")
+                                            </button>
+                                        }
 
                                         <button class="btn btn-sm @(IsUserActive(user) ? "btn-success" : "btn-warning")"
                                                 @onclick='() => ToggleUserActivation(user)'
@@ -103,7 +112,7 @@
     </Authorized>
     <NotAuthorized>
         <div class="alert alert-warning">
-            You must be logged in as an admin or operator to view this page.
+            You must be logged in as an admin, superadmin, or operator to view this page.
         </div>
     </NotAuthorized>
 </AuthorizeView>
@@ -114,11 +123,13 @@
     private bool isLoading = true;
     private string? errorMessage;
     private string? currentUserName;
+    private bool isSuperAdmin;
 
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         currentUserName = authState.User.Identity?.Name;
+        isSuperAdmin = authState.User.IsInRole("superadmin");
 
         try
         {
@@ -147,6 +158,12 @@
         if (IsCurrentUser(user))
         {
             errorMessage = "You cannot delete your own user account.";
+            return;
+        }
+
+        if (userRoles[user.Id].Contains("superadmin") && !isSuperAdmin)
+        {
+            errorMessage = "You cannot delete a super administrator.";
             return;
         }
 
@@ -224,6 +241,12 @@
 
     private async Task ToggleRole(ApplicationUser user, string role)
     {
+        if (!isSuperAdmin)
+        {
+            errorMessage = "Only super administrators can modify roles.";
+            return;
+        }
+
         if (IsCurrentUser(user))
         {
             errorMessage = "You cannot modify your own roles.";

--- a/SonosControl.Web/Shared/NavMenu.razor
+++ b/SonosControl.Web/Shared/NavMenu.razor
@@ -24,7 +24,7 @@
                 <span class="oi oi-cog" aria-hidden="true"></span> Sonos Config
             </NavLink>
         </div>
-        <AuthorizeView Roles="admin">
+        <AuthorizeView Roles="admin,superadmin">
             <Authorized>
                 <div class="nav-item px-3">
                     <NavLink class="nav-link" href="admin/users">
@@ -33,7 +33,7 @@
                 </div>
             </Authorized>
         </AuthorizeView>
-        <AuthorizeView Roles="admin">
+        <AuthorizeView Roles="admin,superadmin">
             <Authorized>
                 <div class="nav-item px-3">
                     <NavLink class="nav-link" href="logs">


### PR DESCRIPTION
## Summary
- Seed new **superadmin** role and assign it to the default admin
- Restrict role changes and superadmin deletion to superadmin users
- Allow only admins to change IP address in config and recognize superadmin across UI
- Add superuser role toggle button accessible only to superadmins

## Testing
- `apt-get update` *(fails: Invalid response from proxy 403)*
- `dotnet test` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbe34db1083219bfb52126a2be64a