### PR TITLE
Persist data protection keys

### DIFF
--- a/SonosControl.Web/Program.cs
+++ b/SonosControl.Web/Program.cs
@@ -4,6 +4,8 @@ using SonosControl.Web.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.DataProtection;
+using System.IO;
 
 using SonosControl.Web.Models; // For ApplicationUser
 using SonosControl.Web.Data;   // For ApplicationDbContext
@@ -55,6 +57,14 @@ builder.Services.ConfigureApplicationCookie(options =>
         return Task.CompletedTask;
     };
 });
+
+// Configure persistent data protection keys so cookies survive restarts
+var keysDirectory = builder.Configuration.GetValue<string>("DataProtection:KeysDirectory")
+                   ?? Path.Combine(builder.Environment.ContentRootPath, "DataProtectionKeys");
+Directory.CreateDirectory(keysDirectory);
+
+builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(keysDirectory));
 
 var app = builder.Build();
 using (var scope = app.Services.CreateScope())


### PR DESCRIPTION
## Summary
- Persist data protection keys to the file system so cookies survive app restarts

## Testing
- `~/dotnet/dotnet build`
- `~/dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c120769f84832182edee49f3034dad