### PR TITLE
Add random playback options for startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ You can change the config to fit your needs or change it later in the UI.
 - [x] Password Reset Page
 - [x] Add option to change the days which the automation should run  
 - [x] Add a "play this song/playlist/station" on startup  
-- [ ] Add play random station on startup toggle  
+- [x] Add play random station on startup toggle
+- [x] Add play random Spotify on startup toggle
 - [ ] Support custom playback durations (e.g., "play for 1 hour after start time")
 - [ ] Enable shuffle toggle for Spotify and Stations
 - [x] Add logs tab to show history of play/stop events with user associated

--- a/SonosControl.DAL/Models/DaySchedule.cs
+++ b/SonosControl.DAL/Models/DaySchedule.cs
@@ -6,5 +6,7 @@ namespace SonosControl.DAL.Models
         public TimeOnly StopTime { get; set; } = new TimeOnly(18, 0);
         public string? StationUrl { get; set; }
         public string? SpotifyUrl { get; set; }
+        public bool PlayRandomStation { get; set; }
+        public bool PlayRandomSpotify { get; set; }
     }
 }

--- a/SonosControl.DAL/Models/SonosSettings.cs
+++ b/SonosControl.DAL/Models/SonosSettings.cs
@@ -25,6 +25,8 @@ namespace SonosControl.DAL.Models
 
         public string? AutoPlayStationUrl { get; set; }
         public string? AutoPlaySpotifyUrl { get; set; }
+        public bool AutoPlayRandomStation { get; set; }
+        public bool AutoPlayRandomSpotify { get; set; }
 
         public Dictionary<DayOfWeek, DaySchedule> DailySchedules { get; set; } = new();
 

--- a/SonosControl.Web/Pages/ConfigPage.razor
+++ b/SonosControl.Web/Pages/ConfigPage.razor
@@ -37,6 +37,8 @@
                     <select class="form-select bg-secondary text-light border-0"
                             @bind="AutoPlaySelection" @bind:event="onchange">
                         <option value="">-- None --</option>
+                        <option value="randomStation">Random Station</option>
+                        <option value="randomSpotify">Random Spotify</option>
                         <optgroup label="Stations">
                             @foreach (var station in _settings.Stations)
                             {
@@ -120,16 +122,18 @@
                                     <input type="time" class="form-control bg-secondary text-light border-0"
                                            @bind-value="schedule.StopTime" @bind-value:event="oninput" @onchange="async _ => await SaveSettings()" />
                                 </td>
-                                <td>
-                                    <select class="form-select bg-secondary text-light border-0"
-                                            value="@GetScheduleSelection(schedule)"
-                                            @onchange="async e => await SetScheduleSelection(schedule, e.Value?.ToString())">
-                                        <option value="">-- None --</option>
-                                        <optgroup label="Stations">
-                                            @foreach (var station in _settings.Stations)
-                                            {
-                                                <option value="station:@station.Url">@station.Name</option>
-                                            }
+                                  <td>
+                                      <select class="form-select bg-secondary text-light border-0"
+                                              value="@GetScheduleSelection(schedule)"
+                                              @onchange="async e => await SetScheduleSelection(schedule, e.Value?.ToString())">
+                                          <option value="">-- None --</option>
+                                          <option value="randomStation">Random Station</option>
+                                          <option value="randomSpotify">Random Spotify</option>
+                                          <optgroup label="Stations">
+                                              @foreach (var station in _settings.Stations)
+                                              {
+                                                  <option value="station:@station.Url">@station.Name</option>
+                                              }
                                         </optgroup>
                                         <optgroup label="Spotify">
                                             @foreach (var track in _settings.SpotifyTracks)
@@ -216,31 +220,44 @@
         }
     }
 
-    private string AutoPlaySelection
-    {
-        get
-        {
-            if (!string.IsNullOrEmpty(_settings!.AutoPlayStationUrl))
-                return $"station:{_settings.AutoPlayStationUrl}";
-            if (!string.IsNullOrEmpty(_settings.AutoPlaySpotifyUrl))
-                return $"spotify:{_settings.AutoPlaySpotifyUrl}";
-            return string.Empty;
-        }
-        set
-        {
-            _settings!.AutoPlayStationUrl = null;
-            _settings.AutoPlaySpotifyUrl = null;
-            if (!string.IsNullOrEmpty(value))
-            {
-                var parts = value.Split(':', 2);
-                if (parts[0] == "station")
-                    _settings.AutoPlayStationUrl = parts[1];
-                else if (parts[0] == "spotify")
-                    _settings.AutoPlaySpotifyUrl = parts[1];
-            }
-            SaveSettings();
-        }
-    }
+      private string AutoPlaySelection
+      {
+          get
+          {
+              if (_settings!.AutoPlayRandomStation)
+                  return "randomStation";
+              if (_settings.AutoPlayRandomSpotify)
+                  return "randomSpotify";
+              if (!string.IsNullOrEmpty(_settings.AutoPlayStationUrl))
+                  return $"station:{_settings.AutoPlayStationUrl}";
+              if (!string.IsNullOrEmpty(_settings.AutoPlaySpotifyUrl))
+                  return $"spotify:{_settings.AutoPlaySpotifyUrl}";
+              return string.Empty;
+          }
+          set
+          {
+              _settings!.AutoPlayRandomStation = false;
+              _settings.AutoPlayRandomSpotify = false;
+              _settings.AutoPlayStationUrl = null;
+              _settings.AutoPlaySpotifyUrl = null;
+              if (!string.IsNullOrEmpty(value))
+              {
+                  if (value == "randomStation")
+                      _settings.AutoPlayRandomStation = true;
+                  else if (value == "randomSpotify")
+                      _settings.AutoPlayRandomSpotify = true;
+                  else
+                  {
+                      var parts = value.Split(':', 2);
+                      if (parts[0] == "station")
+                          _settings.AutoPlayStationUrl = parts[1];
+                      else if (parts[0] == "spotify")
+                          _settings.AutoPlaySpotifyUrl = parts[1];
+                  }
+              }
+              SaveSettings();
+          }
+      }
 
     private async Task SaveSettings()
     {
@@ -252,29 +269,42 @@
         await _uow.ISettingsRepo.WriteSettings(_settings!);
     }
 
-    private string GetScheduleSelection(DaySchedule schedule)
-    {
-        if (!string.IsNullOrEmpty(schedule.StationUrl))
-            return $"station:{schedule.StationUrl}";
-        if (!string.IsNullOrEmpty(schedule.SpotifyUrl))
-            return $"spotify:{schedule.SpotifyUrl}";
-        return string.Empty;
-    }
+      private string GetScheduleSelection(DaySchedule schedule)
+      {
+          if (schedule.PlayRandomStation)
+              return "randomStation";
+          if (schedule.PlayRandomSpotify)
+              return "randomSpotify";
+          if (!string.IsNullOrEmpty(schedule.StationUrl))
+              return $"station:{schedule.StationUrl}";
+          if (!string.IsNullOrEmpty(schedule.SpotifyUrl))
+              return $"spotify:{schedule.SpotifyUrl}";
+          return string.Empty;
+      }
 
-    private async Task SetScheduleSelection(DaySchedule schedule, string? value)
-    {
-        schedule.StationUrl = null;
-        schedule.SpotifyUrl = null;
-        if (!string.IsNullOrEmpty(value))
-        {
-            var parts = value.Split(':', 2);
-            if (parts[0] == "station")
-                schedule.StationUrl = parts[1];
-            else if (parts[0] == "spotify")
-                schedule.SpotifyUrl = parts[1];
-        }
-        await SaveSettings();
-    }
+      private async Task SetScheduleSelection(DaySchedule schedule, string? value)
+      {
+          schedule.PlayRandomStation = false;
+          schedule.PlayRandomSpotify = false;
+          schedule.StationUrl = null;
+          schedule.SpotifyUrl = null;
+          if (!string.IsNullOrEmpty(value))
+          {
+              if (value == "randomStation")
+                  schedule.PlayRandomStation = true;
+              else if (value == "randomSpotify")
+                  schedule.PlayRandomSpotify = true;
+              else
+              {
+                  var parts = value.Split(':', 2);
+                  if (parts[0] == "station")
+                      schedule.StationUrl = parts[1];
+                  else if (parts[0] == "spotify")
+                      schedule.SpotifyUrl = parts[1];
+              }
+          }
+          await SaveSettings();
+      }
 
     private int Volume
     {

--- a/SonosControl.Web/Services/SonosControlService.cs
+++ b/SonosControl.Web/Services/SonosControlService.cs
@@ -39,7 +39,23 @@ namespace SonosControl.Web.Services
 
             if (schedule != null)
             {
-                if (!string.IsNullOrEmpty(schedule.SpotifyUrl))
+                if (schedule.PlayRandomSpotify)
+                {
+                    var url = GetRandomSpotifyUrl(settings);
+                    if (url != null)
+                        await _uow.ISonosConnectorRepo.PlaySpotifyTrackAsync(ip, url);
+                    else
+                        await _uow.ISonosConnectorRepo.StartPlaying(ip);
+                }
+                else if (schedule.PlayRandomStation)
+                {
+                    var url = GetRandomStationUrl(settings);
+                    if (url != null)
+                        await _uow.ISonosConnectorRepo.SetTuneInStationAsync(ip, url);
+                    else
+                        await _uow.ISonosConnectorRepo.StartPlaying(ip);
+                }
+                else if (!string.IsNullOrEmpty(schedule.SpotifyUrl))
                     await _uow.ISonosConnectorRepo.PlaySpotifyTrackAsync(ip, schedule.SpotifyUrl);
                 else if (!string.IsNullOrEmpty(schedule.StationUrl))
                     await _uow.ISonosConnectorRepo.SetTuneInStationAsync(ip, schedule.StationUrl);
@@ -48,7 +64,23 @@ namespace SonosControl.Web.Services
             }
             else
             {
-                if (!string.IsNullOrEmpty(settings!.AutoPlaySpotifyUrl))
+                if (settings.AutoPlayRandomSpotify)
+                {
+                    var url = GetRandomSpotifyUrl(settings);
+                    if (url != null)
+                        await _uow.ISonosConnectorRepo.PlaySpotifyTrackAsync(ip, url);
+                    else
+                        await _uow.ISonosConnectorRepo.StartPlaying(ip);
+                }
+                else if (settings.AutoPlayRandomStation)
+                {
+                    var url = GetRandomStationUrl(settings);
+                    if (url != null)
+                        await _uow.ISonosConnectorRepo.SetTuneInStationAsync(ip, url);
+                    else
+                        await _uow.ISonosConnectorRepo.StartPlaying(ip);
+                }
+                else if (!string.IsNullOrEmpty(settings!.AutoPlaySpotifyUrl))
                     await _uow.ISonosConnectorRepo.PlaySpotifyTrackAsync(ip, settings.AutoPlaySpotifyUrl);
                 else if (!string.IsNullOrEmpty(settings!.AutoPlayStationUrl))
                     await _uow.ISonosConnectorRepo.SetTuneInStationAsync(ip, settings.AutoPlayStationUrl);
@@ -59,6 +91,24 @@ namespace SonosControl.Web.Services
             Console.WriteLine($"{DateTime.Now:g}: Started Playing");
         }
 
+
+        private string? GetRandomStationUrl(SonosSettings settings)
+        {
+            if (settings.Stations == null || settings.Stations.Count == 0)
+                return null;
+
+            var index = Random.Shared.Next(settings.Stations.Count);
+            return settings.Stations[index].Url;
+        }
+
+        private string? GetRandomSpotifyUrl(SonosSettings settings)
+        {
+            if (settings.SpotifyTracks == null || settings.SpotifyTracks.Count == 0)
+                return null;
+
+            var index = Random.Shared.Next(settings.SpotifyTracks.Count);
+            return settings.SpotifyTracks[index].Url;
+        }
 
         private async Task<(SonosSettings settings, DaySchedule? schedule)> WaitUntilStartTime(CancellationToken token)
         {


### PR DESCRIPTION
## Summary
- allow selecting random station or Spotify track on startup
- support per-day random playback in schedules
- add background logic to choose a random station or track

## Testing
- `dotnet build -nologo`

------
https://chatgpt.com/codex/tasks/task_e_68c7daa12e9083219528862d34f5b19e