### PR TITLE
Add anti-forgery tokens to authentication endpoints

### DIFF
--- a/SonosControl.Web/Controllers/AuthController.cs
+++ b/SonosControl.Web/Controllers/AuthController.cs
@@ -25,6 +25,7 @@ namespace SonosControl.Web.Controllers
         }
 
         [HttpPost("login")]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Login(string username, string password, bool rememberMe)
         {
             var result = await _signInManager.PasswordSignInAsync(username, password, rememberMe, false);
@@ -37,6 +38,7 @@ namespace SonosControl.Web.Controllers
         }
 
         [HttpPost("logout")]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Logout()
         {
             await _signInManager.SignOutAsync();
@@ -44,6 +46,7 @@ namespace SonosControl.Web.Controllers
         }
 
         [HttpPost("register")]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Register()
         {
             var settings = await _uow.ISettingsRepo.GetSettings();

--- a/SonosControl.Web/Program.cs
+++ b/SonosControl.Web/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddScoped<IClaimsTransformation, RoleClaimsTransformation>();
 
 builder.Services.AddLocalization();
 builder.Services.AddControllersWithViews();
+builder.Services.AddAntiforgery();
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")));

--- a/SonosControl.Web/Views/Auth/login.cshtml
+++ b/SonosControl.Web/Views/Auth/login.cshtml
@@ -78,6 +78,7 @@ Layout = null;
 </head>
 <body>
 <form method="post" action="/auth/login" class="login-card">
+    @Html.AntiForgeryToken()
     <h2>🔒 Login</h2>
 
     @if (ViewBag.Error != null)

--- a/SonosControl.Web/Views/Auth/logout.cshtml
+++ b/SonosControl.Web/Views/Auth/logout.cshtml
@@ -9,6 +9,7 @@
 </head>
 <body>
 <form method="post" action="/auth/logout">
+    @Html.AntiForgeryToken()
     <button type="submit">Click here if you are not redirected automatically</button>
 </form>
 


### PR DESCRIPTION
## Summary
- secure login, logout, and register actions with `[ValidateAntiForgeryToken]`
- insert `@Html.AntiForgeryToken()` in login and logout views
- enable antiforgery services in startup

## Testing
- `/root/.dotnet/dotnet test` (build succeeded, no tests)

------
https://chatgpt.com/codex/tasks/task_e_68c7f89ac6ec83218142eca8ce63a08b