### PR TITLE
Add unit tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+          include-prerelease: true
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Test
+        run: dotnet test --no-build --verbosity normal

--- a/SonosControl.Tests/SettingsRepoTests.cs
+++ b/SonosControl.Tests/SettingsRepoTests.cs
@@ -1,10 +1,39 @@
 using SonosControl.DAL.Models;
 using SonosControl.DAL.Repos;
+using Xunit;
 
-namespace SonosControl.Testing;
+namespace SonosControl.Tests;
 
 public class SettingsRepoTests
 {
+    [Fact]
+    public async Task WriteAndReadSettings_ReturnsPersistedValues()
+    {
+        var repo = new SettingsRepo();
+
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var originalDir = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(tempDir);
+
+        try
+        {
+            var settings = new SonosSettings { IP_Adress = "1.2.3.4", Volume = 42 };
+            await repo.WriteSettings(settings);
+
+            var result = await repo.GetSettings();
+
+            Assert.NotNull(result);
+            Assert.Equal("1.2.3.4", result!.IP_Adress);
+            Assert.Equal(42, result.Volume);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDir);
+            Directory.Delete(tempDir, true);
+        }
+    }
+
     [Fact]
     public async Task ConcurrentReadsAndWrites_DoNotCorruptSettings()
     {
@@ -47,4 +76,3 @@ public class SettingsRepoTests
         }
     }
 }
-

--- a/SonosControl.Tests/SonosConnectorRepoTests.cs
+++ b/SonosControl.Tests/SonosConnectorRepoTests.cs
@@ -1,0 +1,79 @@
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using SonosControl.DAL.Repos;
+using Xunit;
+
+namespace SonosControl.Tests;
+
+public class SonosConnectorRepoTests
+{
+    private class MockHttpMessageHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+        public HttpResponseMessage Response { get; set; } = new HttpResponseMessage(HttpStatusCode.OK);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            return Task.FromResult(Response);
+        }
+    }
+
+    [Fact]
+    public async Task NextTrack_SendsCorrectSoapRequest()
+    {
+        var handler = new MockHttpMessageHandler();
+        var client = new HttpClient(handler);
+        var repo = new SonosConnectorRepo(client);
+
+        await repo.NextTrack("1.2.3.4");
+
+        Assert.Equal("http://1.2.3.4:1400/MediaRenderer/AVTransport/Control", handler.Request!.RequestUri.ToString());
+        Assert.Equal(HttpMethod.Post, handler.Request!.Method);
+        Assert.Equal("\"urn:schemas-upnp-org:service:AVTransport:1#Next\"", handler.Request!.Content.Headers.GetValues("SOAPACTION").First());
+    }
+
+    [Fact]
+    public async Task GetQueue_ParsesTrackTitles()
+    {
+        var xml = "<dc:title>Track1</dc:title><dc:title>Track2</dc:title>";
+        var handler = new MockHttpMessageHandler
+        {
+            Response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"<s:Envelope><s:Body>{xml}</s:Body></s:Envelope>")
+            }
+        };
+        var client = new HttpClient(handler);
+        var repo = new SonosConnectorRepo(client);
+
+        var result = await repo.GetQueue("1.2.3.4");
+
+        Assert.Equal(new[] { "Track1", "Track2" }, result);
+        Assert.Equal("\"urn:schemas-upnp-org:service:ContentDirectory:1#Browse\"", handler.Request!.Content.Headers.GetValues("SOAPACTION").First());
+    }
+
+    [Fact]
+    public async Task SetTuneInStationAsync_PostsSoapRequest()
+    {
+        var handler = new MockHttpMessageHandler();
+        var client = new HttpClient(handler);
+        var repo = new TestableSonosConnectorRepo(client);
+
+        await repo.SetTuneInStationAsync("1.2.3.4", "example.com/stream");
+
+        Assert.Equal("http://1.2.3.4:1400/MediaRenderer/AVTransport/Control", handler.Request!.RequestUri.ToString());
+        var body = await handler.Request!.Content.ReadAsStringAsync();
+        Assert.Contains("x-rincon-mp3radio://example.com/stream", body);
+        Assert.Equal("\"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI\"", handler.Request!.Content.Headers.GetValues("SOAPACTION").First());
+    }
+
+    private class TestableSonosConnectorRepo : SonosConnectorRepo
+    {
+        public TestableSonosConnectorRepo(HttpClient client) : base(client) { }
+        public override Task StartPlaying(string ip) => Task.CompletedTask;
+    }
+}

--- a/SonosControl.Tests/SonosControl.Tests.csproj
+++ b/SonosControl.Tests/SonosControl.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SonosControl.DAL\SonosControl.DAL.csproj" />
+    <ProjectReference Include="..\SonosControl.Web\SonosControl.Web.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.69" />
   </ItemGroup>
 
 </Project>

--- a/SonosControl.Tests/SonosControlServiceTests.cs
+++ b/SonosControl.Tests/SonosControlServiceTests.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics;
+using System.Reflection;
+using Moq;
+using SonosControl.DAL.Interfaces;
+using SonosControl.DAL.Models;
+using SonosControl.Web.Services;
+using Xunit;
+
+namespace SonosControl.Tests;
+
+public class SonosControlServiceTests
+{
+    private static Task<(SonosSettings settings, DaySchedule? schedule)> InvokeWait(SonosControlService svc, CancellationToken token)
+    {
+        var method = typeof(SonosControlService).GetMethod("WaitUntilStartTime", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var task = (Task<(SonosSettings, DaySchedule?)>)method.Invoke(svc, new object[] { token })!;
+        return task;
+    }
+
+    [Fact]
+    public async Task WaitUntilStartTime_WaitsUntilSettingStart()
+    {
+        var settings = new SonosSettings
+        {
+            StartTime = TimeOnly.FromDateTime(DateTime.Now.AddMilliseconds(500))
+        };
+        var settingsRepo = new Mock<ISettingsRepo>();
+        settingsRepo.Setup(r => r.GetSettings()).ReturnsAsync(settings);
+
+        var uow = new Mock<IUnitOfWork>();
+        uow.SetupGet(u => u.ISettingsRepo).Returns(settingsRepo.Object);
+
+        var svc = new SonosControlService(uow.Object);
+
+        var sw = Stopwatch.StartNew();
+        var result = await InvokeWait(svc, CancellationToken.None);
+        sw.Stop();
+
+        Assert.True(sw.ElapsedMilliseconds >= 300, $"Elapsed {sw.ElapsedMilliseconds}ms");
+        Assert.Same(settings, result.settings);
+        Assert.Null(result.schedule);
+    }
+
+    [Fact]
+    public async Task WaitUntilStartTime_UsesDailySchedule()
+    {
+        var schedule = new DaySchedule
+        {
+            StartTime = TimeOnly.FromDateTime(DateTime.Now.AddMilliseconds(200))
+        };
+        var settings = new SonosSettings
+        {
+            StartTime = TimeOnly.FromDateTime(DateTime.Now.AddHours(1)),
+            DailySchedules = new Dictionary<DayOfWeek, DaySchedule>
+            {
+                [DateTime.Now.DayOfWeek] = schedule
+            }
+        };
+
+        var settingsRepo = new Mock<ISettingsRepo>();
+        settingsRepo.Setup(r => r.GetSettings()).ReturnsAsync(settings);
+
+        var uow = new Mock<IUnitOfWork>();
+        uow.SetupGet(u => u.ISettingsRepo).Returns(settingsRepo.Object);
+
+        var svc = new SonosControlService(uow.Object);
+
+        var sw = Stopwatch.StartNew();
+        var result = await InvokeWait(svc, CancellationToken.None);
+        sw.Stop();
+
+        Assert.True(sw.ElapsedMilliseconds >= 150, $"Elapsed {sw.ElapsedMilliseconds}ms");
+        Assert.Same(schedule, result.schedule);
+    }
+}

--- a/SonosControl.sln
+++ b/SonosControl.sln
@@ -7,26 +7,54 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SonosControl.Web", "SonosCo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SonosControl.DAL", "SonosControl.DAL\SonosControl.DAL.csproj", "{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SonosControl.Testing", "SonosControl.Testing\SonosControl.Testing.csproj", "{A2C61640-5E9B-48DB-9E34-4D1946FF911A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SonosControl.Tests", "SonosControl.Tests\SonosControl.Tests.csproj", "{B20DC4EC-F6EB-409F-A886-F67E35C374E1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{FDE357D3-3F16-46D3-9256-8692636D0212}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FDE357D3-3F16-46D3-9256-8692636D0212}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDE357D3-3F16-46D3-9256-8692636D0212}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FDE357D3-3F16-46D3-9256-8692636D0212}.Debug|x64.Build.0 = Debug|Any CPU
+		{FDE357D3-3F16-46D3-9256-8692636D0212}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FDE357D3-3F16-46D3-9256-8692636D0212}.Debug|x86.Build.0 = Debug|Any CPU
 		{FDE357D3-3F16-46D3-9256-8692636D0212}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDE357D3-3F16-46D3-9256-8692636D0212}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDE357D3-3F16-46D3-9256-8692636D0212}.Release|x64.ActiveCfg = Release|Any CPU
+		{FDE357D3-3F16-46D3-9256-8692636D0212}.Release|x64.Build.0 = Release|Any CPU
+		{FDE357D3-3F16-46D3-9256-8692636D0212}.Release|x86.ActiveCfg = Release|Any CPU
+		{FDE357D3-3F16-46D3-9256-8692636D0212}.Release|x86.Build.0 = Release|Any CPU
 		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Debug|x64.Build.0 = Debug|Any CPU
+		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Debug|x86.Build.0 = Debug|Any CPU
 		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A2C61640-5E9B-48DB-9E34-4D1946FF911A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A2C61640-5E9B-48DB-9E34-4D1946FF911A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A2C61640-5E9B-48DB-9E34-4D1946FF911A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A2C61640-5E9B-48DB-9E34-4D1946FF911A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Release|x64.ActiveCfg = Release|Any CPU
+		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Release|x64.Build.0 = Release|Any CPU
+		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Release|x86.ActiveCfg = Release|Any CPU
+		{62A00D90-2FC3-4F10-9663-B7C24E96D1AF}.Release|x86.Build.0 = Release|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Debug|x64.Build.0 = Debug|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Debug|x86.Build.0 = Debug|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Release|x64.ActiveCfg = Release|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Release|x64.Build.0 = Release|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Release|x86.ActiveCfg = Release|Any CPU
+		{B20DC4EC-F6EB-409F-A886-F67E35C374E1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- rename SonosControl.Testing to SonosControl.Tests and convert to xUnit with Moq support
- add tests for SettingsRepo, SonosControlService scheduling, and SonosConnectorRepo HTTP interactions
- enable GitHub Actions workflow to build and test the solution

## Testing
- `dotnet test --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68c820866d0483218bdc807a3057cf26