### PR TITLE
Fix route authorization for role-restricted pages

### DIFF
--- a/SonosControl.Web/App.razor
+++ b/SonosControl.Web/App.razor
@@ -1,7 +1,18 @@
-﻿<CascadingAuthenticationState>
+<CascadingAuthenticationState>
     <Router AppAssembly="@typeof(App).Assembly">
         <Found Context="routeData">
-            <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                <NotAuthorized>
+                    <LayoutView Layout="@typeof(MainLayout)">
+                        <p class="alert alert-warning m-3">You are not authorized to access this page.</p>
+                    </LayoutView>
+                </NotAuthorized>
+                <Authorizing>
+                    <LayoutView Layout="@typeof(MainLayout)">
+                        <p class="m-3">Authorizing...</p>
+                    </LayoutView>
+                </Authorizing>
+            </AuthorizeRouteView>
             <FocusOnNavigate RouteData="@routeData" Selector="h1" />
         </Found>
         <NotFound>


### PR DESCRIPTION
## Summary
- update the Blazor app router to use AuthorizeRouteView so component-level [Authorize] attributes are enforced
- provide Authorizing and NotAuthorized placeholders that render inside the main layout

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c900cb7eb8832192c6fbd06c69df52