### PR TITLE
Refactor Sonos connector HTTP usage and add tests

### DIFF
--- a/SonosControl.DAL/Interfaces/ISonosConnectorRepo.cs
+++ b/SonosControl.DAL/Interfaces/ISonosConnectorRepo.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Threading;
+
 namespace SonosControl.DAL.Interfaces
 {
     public interface ISonosConnectorRepo
@@ -8,15 +11,15 @@ namespace SonosControl.DAL.Interfaces
         Task SetVolume(string ip, int volume);
         Task StartPlaying(string ip);
         Task StopPlaying(string ip);
-        Task<string> GetCurrentTrackAsync(string ip);
-        Task<(TimeSpan Position, TimeSpan Duration)> GetTrackProgressAsync(string ip);
-        Task SetTuneInStationAsync(string ip, string stationUri);
-        Task<string> GetCurrentStationAsync(string ip);
-        Task<string?> SearchSpotifyTrackAsync(string query, string accessToken);
-        Task PlaySpotifyTrackAsync(string ip, string spotifyUri);
-        Task ClearQueue(string ip);
-        Task<List<string>> GetQueue(string ip);
-        Task PreviousTrack(string ip);
-        Task NextTrack(string ip);
+        Task<string> GetCurrentTrackAsync(string ip, CancellationToken cancellationToken = default);
+        Task<(TimeSpan Position, TimeSpan Duration)> GetTrackProgressAsync(string ip, CancellationToken cancellationToken = default);
+        Task SetTuneInStationAsync(string ip, string stationUri, CancellationToken cancellationToken = default);
+        Task<string> GetCurrentStationAsync(string ip, CancellationToken cancellationToken = default);
+        Task<string?> SearchSpotifyTrackAsync(string query, string accessToken, CancellationToken cancellationToken = default);
+        Task PlaySpotifyTrackAsync(string ip, string spotifyUri, string? fallbackStationUri = null, CancellationToken cancellationToken = default);
+        Task ClearQueue(string ip, CancellationToken cancellationToken = default);
+        Task<List<string>> GetQueue(string ip, CancellationToken cancellationToken = default);
+        Task PreviousTrack(string ip, CancellationToken cancellationToken = default);
+        Task NextTrack(string ip, CancellationToken cancellationToken = default);
     }
 }

--- a/SonosControl.DAL/Repos/UnitOfWork.cs
+++ b/SonosControl.DAL/Repos/UnitOfWork.cs
@@ -1,15 +1,22 @@
-﻿using SonosControl.DAL.Interfaces;
+using System.Net.Http;
+using SonosControl.DAL.Interfaces;
 
 namespace SonosControl.DAL.Repos
 {
     public class UnitOfWork : IUnitOfWork
     {
+        private readonly IHttpClientFactory _httpClientFactory;
         private SettingsRepo? settingsRepo;
         private SonosConnectorRepo? sonosConnectorRepo;
         private HolidayRepo? holidayRepo;
 
+        public UnitOfWork(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
         public ISettingsRepo ISettingsRepo => settingsRepo ?? new SettingsRepo();
         public IHolidayRepo IHolidayRepo => holidayRepo ?? new HolidayRepo();
-        public ISonosConnectorRepo ISonosConnectorRepo => sonosConnectorRepo ?? new SonosConnectorRepo();
+        public ISonosConnectorRepo ISonosConnectorRepo => sonosConnectorRepo ?? new SonosConnectorRepo(_httpClientFactory);
     }
 }

--- a/SonosControl.DAL/SonosControl.DAL.csproj
+++ b/SonosControl.DAL/SonosControl.DAL.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="ByteDev.Sonos" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/SonosControl.Tests/SonosConnectorRepoTests.cs
+++ b/SonosControl.Tests/SonosConnectorRepoTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -10,70 +12,187 @@ namespace SonosControl.Tests;
 
 public class SonosConnectorRepoTests
 {
-    private class MockHttpMessageHandler : HttpMessageHandler
+    private sealed class QueueHttpMessageHandler : HttpMessageHandler
     {
-        public HttpRequestMessage? Request { get; private set; }
-        public HttpResponseMessage Response { get; set; } = new HttpResponseMessage(HttpStatusCode.OK);
+        internal sealed record CapturedRequest(HttpMethod Method, Uri? Uri, string? SoapAction, string? Body);
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        private readonly Queue<HttpResponseMessage> _responses = new();
+        public List<CapturedRequest> Requests { get; } = new();
+
+        public void Enqueue(HttpResponseMessage response)
         {
-            Request = request;
-            return Task.FromResult(Response);
+            _responses.Enqueue(response);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string? body = null;
+            string? soapAction = null;
+
+            if (request.Content is not null)
+            {
+                body = await request.Content.ReadAsStringAsync(cancellationToken);
+
+                if (request.Content.Headers.TryGetValues("SOAPACTION", out var values))
+                {
+                    soapAction = values.FirstOrDefault();
+                }
+            }
+
+            Requests.Add(new CapturedRequest(request.Method, request.RequestUri, soapAction, body));
+
+            if (_responses.Count == 0)
+            {
+                throw new InvalidOperationException("No response configured.");
+            }
+
+            return _responses.Dequeue();
+        }
+    }
+
+    private sealed class TestHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+
+        public TestHttpClientFactory(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public HttpClient CreateClient(string name) => _client;
+    }
+
+    private sealed class TestableSonosConnectorRepo : SonosConnectorRepo
+    {
+        public int StartPlayingCallCount { get; private set; }
+
+        public TestableSonosConnectorRepo(IHttpClientFactory httpClientFactory)
+            : base(httpClientFactory)
+        {
+        }
+
+        public override Task StartPlaying(string ip)
+        {
+            StartPlayingCallCount++;
+            return Task.CompletedTask;
         }
     }
 
     [Fact]
     public async Task NextTrack_SendsCorrectSoapRequest()
     {
-        var handler = new MockHttpMessageHandler();
+        var handler = new QueueHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK));
         var client = new HttpClient(handler);
-        var repo = new SonosConnectorRepo(client);
+        var repo = new SonosConnectorRepo(new TestHttpClientFactory(client));
 
         await repo.NextTrack("1.2.3.4");
 
-        Assert.Equal("http://1.2.3.4:1400/MediaRenderer/AVTransport/Control", handler.Request!.RequestUri.ToString());
-        Assert.Equal(HttpMethod.Post, handler.Request!.Method);
-        Assert.Equal("\"urn:schemas-upnp-org:service:AVTransport:1#Next\"", handler.Request!.Content.Headers.GetValues("SOAPACTION").First());
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal("http://1.2.3.4:1400/MediaRenderer/AVTransport/Control", request.Uri!.ToString());
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("\"urn:schemas-upnp-org:service:AVTransport:1#Next\"", request.SoapAction);
     }
 
     [Fact]
     public async Task GetQueue_ParsesTrackTitles()
     {
-        var xml = "<dc:title>Track1</dc:title><dc:title>Track2</dc:title>";
-        var handler = new MockHttpMessageHandler
+        var handler = new QueueHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent($"<s:Envelope><s:Body>{xml}</s:Body></s:Envelope>")
-            }
-        };
+            Content = new StringContent("<s:Envelope><s:Body><dc:title>Track1</dc:title><dc:title>Track2</dc:title></s:Body></s:Envelope>")
+        });
         var client = new HttpClient(handler);
-        var repo = new SonosConnectorRepo(client);
+        var repo = new SonosConnectorRepo(new TestHttpClientFactory(client));
 
         var result = await repo.GetQueue("1.2.3.4");
 
         Assert.Equal(new[] { "Track1", "Track2" }, result);
-        Assert.Equal("\"urn:schemas-upnp-org:service:ContentDirectory:1#Browse\"", handler.Request!.Content.Headers.GetValues("SOAPACTION").First());
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal("\"urn:schemas-upnp-org:service:ContentDirectory:1#Browse\"", request.SoapAction);
     }
 
     [Fact]
-    public async Task SetTuneInStationAsync_PostsSoapRequest()
+    public async Task SetTuneInStationAsync_Success_PostsSoapRequestAndStartsPlayback()
     {
-        var handler = new MockHttpMessageHandler();
+        var handler = new QueueHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK));
         var client = new HttpClient(handler);
-        var repo = new TestableSonosConnectorRepo(client);
+        var repo = new TestableSonosConnectorRepo(new TestHttpClientFactory(client));
 
         await repo.SetTuneInStationAsync("1.2.3.4", "example.com/stream");
 
-        Assert.Equal("http://1.2.3.4:1400/MediaRenderer/AVTransport/Control", handler.Request!.RequestUri.ToString());
-        var body = await handler.Request!.Content.ReadAsStringAsync();
-        Assert.Contains("x-rincon-mp3radio://example.com/stream", body);
-        Assert.Equal("\"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI\"", handler.Request!.Content.Headers.GetValues("SOAPACTION").First());
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal("http://1.2.3.4:1400/MediaRenderer/AVTransport/Control", request.Uri!.ToString());
+        Assert.NotNull(request.Body);
+        Assert.Contains("x-rincon-mp3radio://example.com/stream", request.Body);
+        Assert.Equal("\"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI\"", request.SoapAction);
+        Assert.Equal(1, repo.StartPlayingCallCount);
     }
 
-    private class TestableSonosConnectorRepo : SonosConnectorRepo
+    [Fact]
+    public async Task SetTuneInStationAsync_Failure_DoesNotStartPlayback()
     {
-        public TestableSonosConnectorRepo(HttpClient client) : base(client) { }
-        public override Task StartPlaying(string ip) => Task.CompletedTask;
+        var handler = new QueueHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var client = new HttpClient(handler);
+        var repo = new TestableSonosConnectorRepo(new TestHttpClientFactory(client));
+
+        await repo.SetTuneInStationAsync("1.2.3.4", "example.com/stream");
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal("\"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI\"", request.SoapAction);
+        Assert.Equal(0, repo.StartPlayingCallCount);
+    }
+
+    [Fact]
+    public async Task PlaySpotifyTrackAsync_Success_UsesFallbackAndStartsPlayback()
+    {
+        var handler = new QueueHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK));
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("<root><UDN>uuid:RINCON_ABC123</UDN></root>")
+        });
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = new HttpClient(handler);
+        var repo = new TestableSonosConnectorRepo(new TestHttpClientFactory(client));
+
+        await repo.PlaySpotifyTrackAsync("1.2.3.4", "https://open.spotify.com/track/12345", "fallback-station");
+
+        Assert.Equal(3, handler.Requests.Count);
+
+        var fallbackRequest = handler.Requests[0];
+        Assert.Equal(HttpMethod.Post, fallbackRequest.Method);
+        Assert.NotNull(fallbackRequest.Body);
+        Assert.Contains("fallback-station", fallbackRequest.Body);
+
+        var deviceDescriptionRequest = handler.Requests[1];
+        Assert.Equal(HttpMethod.Get, deviceDescriptionRequest.Method);
+        Assert.Equal("http://1.2.3.4:1400/xml/device_description.xml", deviceDescriptionRequest.Uri!.ToString());
+
+        var spotifyRequest = handler.Requests[2];
+        Assert.Equal("\"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI\"", spotifyRequest.SoapAction);
+        Assert.Equal(2, repo.StartPlayingCallCount);
+    }
+
+    [Fact]
+    public async Task PlaySpotifyTrackAsync_Failure_DoesNotStartPlayback()
+    {
+        var handler = new QueueHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("<root><UDN>uuid:RINCON_ABC123</UDN></root>")
+        });
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var client = new HttpClient(handler);
+        var repo = new TestableSonosConnectorRepo(new TestHttpClientFactory(client));
+
+        await repo.PlaySpotifyTrackAsync("1.2.3.4", "https://open.spotify.com/track/12345");
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+        Assert.Equal(0, repo.StartPlayingCallCount);
     }
 }

--- a/SonosControl.Web/Program.cs
+++ b/SonosControl.Web/Program.cs
@@ -16,6 +16,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
+builder.Services.AddHttpClient();
 builder.Services.AddTransient<IUnitOfWork, UnitOfWork>();
 
 builder.Services.AddHostedService<SonosControlService>();


### PR DESCRIPTION
## Summary
- refactor `SonosConnectorRepo` to use `IHttpClientFactory`, accept cancellation tokens, and support configurable Spotify fallbacks
- update DI setup and unit of work to supply the HTTP client factory dependency
- expand unit tests to cover success and failure paths for TuneIn and Spotify playback

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c8fcf125a883218fbd2b7d31b2decf