### PR TITLE
Redirect unauthorized visitors to login page

### DIFF
--- a/SonosControl.Web/App.razor
+++ b/SonosControl.Web/App.razor
@@ -1,7 +1,27 @@
-﻿<CascadingAuthenticationState>
+<CascadingAuthenticationState>
     <Router AppAssembly="@typeof(App).Assembly">
         <Found Context="routeData">
-            <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                <NotAuthorized>
+                    <AuthorizeView>
+                        <Authorized>
+                            <LayoutView Layout="@typeof(MainLayout)">
+                                <p class="alert alert-warning m-3">You are not authorized to access this page.</p>
+                            </LayoutView>
+                        </Authorized>
+                        <NotAuthorized>
+                            <LayoutView Layout="@typeof(MainLayout)">
+                                <RedirectToLogin />
+                            </LayoutView>
+                        </NotAuthorized>
+                    </AuthorizeView>
+                </NotAuthorized>
+                <Authorizing>
+                    <LayoutView Layout="@typeof(MainLayout)">
+                        <p class="m-3">Authorizing...</p>
+                    </LayoutView>
+                </Authorizing>
+            </AuthorizeRouteView>
             <FocusOnNavigate RouteData="@routeData" Selector="h1" />
         </Found>
         <NotFound>

--- a/SonosControl.Web/Shared/RedirectToLogin.razor
+++ b/SonosControl.Web/Shared/RedirectToLogin.razor
@@ -1,0 +1,29 @@
+@inject NavigationManager Navigation
+
+<p class="m-3">Redirecting to login...</p>
+
+@code {
+    private bool _hasNavigated;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (!firstRender || _hasNavigated)
+        {
+            return;
+        }
+
+        _hasNavigated = true;
+        var relativePath = Navigation.ToBaseRelativePath(Navigation.Uri);
+
+        if (!string.IsNullOrEmpty(relativePath) && !relativePath.StartsWith("/"))
+        {
+            relativePath = $"/{relativePath}";
+        }
+
+        var target = string.IsNullOrEmpty(relativePath)
+            ? "/auth/login"
+            : $"/auth/login?returnUrl={Uri.EscapeDataString(relativePath)}";
+
+        Navigation.NavigateTo(target, true);
+    }
+}


### PR DESCRIPTION
## Summary
- add a redirect flow for unauthenticated visitors in the router's not-authorized handler so they land on the login page
- show a friendly in-app message only for authenticated users who lack the required roles

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c900cb7eb8832192c6fbd06c69df52