### PR TITLE
Prevent layout flash before login redirect

### DIFF
--- a/SonosControl.Web/App.razor
+++ b/SonosControl.Web/App.razor
@@ -5,14 +5,10 @@
                 <NotAuthorized Context="routeViewContext">
                     <AuthorizeView>
                         <Authorized Context="authorizedState">
-                            <LayoutView Layout="@typeof(MainLayout)">
-                                <p class="alert alert-warning m-3">You are not authorized to access this page.</p>
-                            </LayoutView>
+                            <p class="alert alert-warning m-3">You are not authorized to access this page.</p>
                         </Authorized>
                         <NotAuthorized Context="unauthorizedState">
-                            <LayoutView Layout="@typeof(MainLayout)">
-                                <RedirectToLogin />
-                            </LayoutView>
+                            <RedirectToLogin />
                         </NotAuthorized>
                     </AuthorizeView>
                 </NotAuthorized>

--- a/SonosControl.Web/Shared/RedirectToLogin.razor
+++ b/SonosControl.Web/Shared/RedirectToLogin.razor
@@ -1,18 +1,8 @@
 @inject NavigationManager Navigation
 
-<p class="m-3">Redirecting to login...</p>
-
 @code {
-    private bool _hasNavigated;
-
-    protected override void OnAfterRender(bool firstRender)
+    protected override void OnInitialized()
     {
-        if (!firstRender || _hasNavigated)
-        {
-            return;
-        }
-
-        _hasNavigated = true;
         var relativePath = Navigation.ToBaseRelativePath(Navigation.Uri);
 
         if (!string.IsNullOrEmpty(relativePath) && !relativePath.StartsWith("/"))


### PR DESCRIPTION
## Summary
- move the login redirect logic into `OnInitialized` so unauthenticated users navigate before the component renders
- remove the `MainLayout` wrapper from unauthorized views so authenticated users without the right role only see the warning message

## Testing
- `dotnet test` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c936eb5f0c8321ba03de8b30cc1957