### PR TITLE
Handle past start times when scheduling playback

### DIFF
--- a/SonosControl.Tests/SonosControlServiceTests.cs
+++ b/SonosControl.Tests/SonosControlServiceTests.cs
@@ -6,6 +6,8 @@ using SonosControl.DAL.Models;
 using SonosControl.Web.Services;
 using Xunit;
 
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
 namespace SonosControl.Tests;
 
 public class SonosControlServiceTests
@@ -20,9 +22,13 @@ public class SonosControlServiceTests
     [Fact]
     public async Task WaitUntilStartTime_WaitsUntilSettingStart()
     {
+        var initial = new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero);
+        var timeProvider = new ManualTimeProvider(initial);
+
+        var start = TimeOnly.FromDateTime(initial.AddMilliseconds(500).DateTime);
         var settings = new SonosSettings
         {
-            StartTime = TimeOnly.FromDateTime(DateTime.Now.AddMilliseconds(500))
+            StartTime = start
         };
         var settingsRepo = new Mock<ISettingsRepo>();
         settingsRepo.Setup(r => r.GetSettings()).ReturnsAsync(settings);
@@ -30,13 +36,17 @@ public class SonosControlServiceTests
         var uow = new Mock<IUnitOfWork>();
         uow.SetupGet(u => u.ISettingsRepo).Returns(settingsRepo.Object);
 
-        var svc = new SonosControlService(uow.Object);
+        var svc = new SonosControlService(uow.Object, timeProvider, timeProvider.DelayAsync);
 
-        var sw = Stopwatch.StartNew();
-        var result = await InvokeWait(svc, CancellationToken.None);
-        sw.Stop();
+        var waitTask = InvokeWait(svc, CancellationToken.None);
 
-        Assert.True(sw.ElapsedMilliseconds >= 300, $"Elapsed {sw.ElapsedMilliseconds}ms");
+        timeProvider.Advance(TimeSpan.FromMilliseconds(300));
+        Assert.False(waitTask.IsCompleted);
+
+        timeProvider.Advance(TimeSpan.FromMilliseconds(200));
+
+        var result = await waitTask;
+
         Assert.Same(settings, result.settings);
         Assert.Null(result.schedule);
     }
@@ -71,5 +81,216 @@ public class SonosControlServiceTests
 
         Assert.True(sw.ElapsedMilliseconds >= 150, $"Elapsed {sw.ElapsedMilliseconds}ms");
         Assert.Same(schedule, result.schedule);
+    }
+
+    [Fact]
+    public async Task WaitUntilStartTime_WhenStartTimeAlreadyPassed_WaitsForNextDay_DefaultSettings()
+    {
+        var startTime = new TimeOnly(7, 30);
+        var initial = new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero);
+        var timeProvider = new ManualTimeProvider(initial);
+
+        var settings = new SonosSettings
+        {
+            StartTime = startTime
+        };
+
+        var settingsRepo = new Mock<ISettingsRepo>();
+        settingsRepo.Setup(r => r.GetSettings()).ReturnsAsync(settings);
+
+        var uow = new Mock<IUnitOfWork>();
+        uow.SetupGet(u => u.ISettingsRepo).Returns(settingsRepo.Object);
+
+        var svc = new SonosControlService(uow.Object, timeProvider, timeProvider.DelayAsync);
+
+        var waitTask = InvokeWait(svc, CancellationToken.None);
+
+        await Task.Delay(50);
+        Assert.False(waitTask.IsCompleted);
+
+        var now = timeProvider.LocalNow;
+        var nextRun = new DateTimeOffset(now.Date.AddDays(1).Add(startTime.ToTimeSpan()), now.Offset);
+        var advanceAlmostToStart = nextRun - now - TimeSpan.FromSeconds(1);
+        Assert.True(advanceAlmostToStart > TimeSpan.Zero);
+
+        timeProvider.Advance(advanceAlmostToStart);
+        Assert.False(waitTask.IsCompleted);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var result = await waitTask;
+
+        Assert.Same(settings, result.settings);
+        Assert.Null(result.schedule);
+        Assert.Equal(nextRun, timeProvider.LocalNow);
+        var expectedDay = (DayOfWeek)(((int)initial.DayOfWeek + 1) % 7);
+        Assert.Equal(expectedDay, timeProvider.LocalNow.DayOfWeek);
+    }
+
+    [Fact]
+    public async Task WaitUntilStartTime_WhenTodayScheduleHasPassed_UsesNextDaySchedule()
+    {
+        var initial = new DateTimeOffset(2024, 1, 1, 23, 55, 0, TimeSpan.Zero);
+        var timeProvider = new ManualTimeProvider(initial);
+
+        var today = initial.DayOfWeek;
+        var tomorrow = (DayOfWeek)(((int)today + 1) % 7);
+
+        var todaySchedule = new DaySchedule
+        {
+            StartTime = new TimeOnly(23, 50)
+        };
+
+        var tomorrowSchedule = new DaySchedule
+        {
+            StartTime = new TimeOnly(0, 1),
+            SpotifyUrl = "spotify:track:example"
+        };
+
+        var settings = new SonosSettings
+        {
+            StartTime = new TimeOnly(6, 0),
+            DailySchedules = new Dictionary<DayOfWeek, DaySchedule>
+            {
+                [today] = todaySchedule,
+                [tomorrow] = tomorrowSchedule
+            }
+        };
+
+        var settingsRepo = new Mock<ISettingsRepo>();
+        settingsRepo.Setup(r => r.GetSettings()).ReturnsAsync(settings);
+
+        var uow = new Mock<IUnitOfWork>();
+        uow.SetupGet(u => u.ISettingsRepo).Returns(settingsRepo.Object);
+
+        var svc = new SonosControlService(uow.Object, timeProvider, timeProvider.DelayAsync);
+
+        var waitTask = InvokeWait(svc, CancellationToken.None);
+
+        await Task.Delay(50);
+        Assert.False(waitTask.IsCompleted);
+
+        var now = timeProvider.LocalNow;
+        var nextRun = new DateTimeOffset(now.Date.AddDays(1).Add(tomorrowSchedule.StartTime.ToTimeSpan()), now.Offset);
+        var advanceAlmostToStart = nextRun - now - TimeSpan.FromSeconds(1);
+        Assert.True(advanceAlmostToStart > TimeSpan.Zero);
+
+        timeProvider.Advance(advanceAlmostToStart);
+        Assert.False(waitTask.IsCompleted);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var result = await waitTask;
+
+        Assert.Same(settings, result.settings);
+        Assert.Same(tomorrowSchedule, result.schedule);
+        Assert.Equal(nextRun, timeProvider.LocalNow);
+        Assert.Equal(tomorrow, timeProvider.LocalNow.DayOfWeek);
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _current;
+        private readonly SortedList<DateTimeOffset, List<TaskCompletionSource<bool>>> _scheduled = new();
+        private readonly object _lock = new();
+
+        public ManualTimeProvider(DateTimeOffset current)
+        {
+            _current = current;
+        }
+
+        public DateTimeOffset LocalNow
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _current;
+                }
+            }
+        }
+
+        public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Utc;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            lock (_lock)
+            {
+                return _current.ToUniversalTime();
+            }
+        }
+
+        public void Advance(TimeSpan delta)
+        {
+            if (delta < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(delta));
+
+            lock (_lock)
+            {
+                _current = _current.Add(delta);
+                CompleteDueTimers();
+            }
+        }
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken = default)
+        {
+            if (delay <= TimeSpan.Zero)
+            {
+                return Task.CompletedTask;
+            }
+
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            DateTimeOffset target;
+
+            lock (_lock)
+            {
+                target = _current.Add(delay);
+                if (!_scheduled.TryGetValue(target, out var waiters))
+                {
+                    waiters = new List<TaskCompletionSource<bool>>();
+                    _scheduled.Add(target, waiters);
+                }
+                waiters.Add(tcs);
+                CompleteDueTimers();
+            }
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                cancellationToken.Register(() =>
+                {
+                    lock (_lock)
+                    {
+                        if (_scheduled.TryGetValue(target, out var list))
+                        {
+                            list.Remove(tcs);
+                            if (list.Count == 0)
+                                _scheduled.Remove(target);
+                        }
+                    }
+
+                    tcs.TrySetCanceled(cancellationToken);
+                });
+            }
+
+            return tcs.Task;
+        }
+
+        private void CompleteDueTimers()
+        {
+            while (_scheduled.Count > 0)
+            {
+                var key = _scheduled.Keys[0];
+                if (key > _current)
+                    break;
+
+                var waiters = _scheduled.Values[0];
+                _scheduled.RemoveAt(0);
+
+                foreach (var waiter in waiters)
+                {
+                    waiter.TrySetResult(true);
+                }
+            }
+        }
     }
 }

--- a/SonosControl.Web/Services/SonosControlService.cs
+++ b/SonosControl.Web/Services/SonosControlService.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using SonosControl.DAL.Interfaces;
 using SonosControl.DAL.Models;
 
@@ -6,10 +7,14 @@ namespace SonosControl.Web.Services
     public class SonosControlService : BackgroundService
     {
         private IUnitOfWork _uow;
+        private readonly TimeProvider _timeProvider;
+        private readonly Func<TimeSpan, CancellationToken, Task> _delay;
 
-        public SonosControlService(IUnitOfWork uow)
+        public SonosControlService(IUnitOfWork uow, TimeProvider? timeProvider = null, Func<TimeSpan, CancellationToken, Task>? delay = null)
         {
             _uow = uow;
+            _timeProvider = timeProvider ?? TimeProvider.System;
+            _delay = delay ?? TaskDelay;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -113,44 +118,109 @@ namespace SonosControl.Web.Services
         private async Task<(SonosSettings settings, DaySchedule? schedule)> WaitUntilStartTime(CancellationToken token)
         {
             TimeOnly? previousStart = null;
+            DayOfWeek? previousDay = null;
+            DateTimeOffset? previousTarget = null;
 
             while (!token.IsCancellationRequested)
             {
                 var settings = await _uow.ISettingsRepo.GetSettings();
-                var today = DateTime.Now.DayOfWeek;
+                if (settings is null)
+                {
+                    await _delay(TimeSpan.FromSeconds(1), token);
+                    continue;
+                }
+                var now = _timeProvider.GetLocalNow();
 
-                DaySchedule? schedule = null;
-                if (settings!.DailySchedules != null && settings.DailySchedules.TryGetValue(today, out var sched))
-                    schedule = sched;
+                var currentTime = TimeOnly.FromDateTime(now.LocalDateTime);
+                var todaySchedule = GetScheduleForDay(settings, now.DayOfWeek);
+                var todayStart = todaySchedule?.StartTime ?? settings.StartTime;
 
-                var start = schedule?.StartTime ?? settings.StartTime;
-                var now = TimeOnly.FromDateTime(DateTime.Now);
+                if (previousDay == now.DayOfWeek && previousStart == todayStart && todayStart <= currentTime)
+                    return (settings, todaySchedule);
 
-                if (start <= now)
+                var (target, schedule, start, startDay) = DetermineNextStart(settings, now);
+
+                if (target <= now)
                     return (settings, schedule);
 
-                if (previousStart != start)
-                {
-                    var totalMs = (int)(start - now).TotalMilliseconds;
-                    TimeSpan t = TimeSpan.FromMilliseconds(totalMs);
-                    string delayInMs = string.Format("{0:D2}h:{1:D2}m:{2:D2}s:{3:D3}ms",
-                            t.Hours,
-                            t.Minutes,
-                            t.Seconds,
-                            t.Milliseconds);
+                var remaining = target - now;
 
-                    Console.WriteLine(DateTime.Now.ToString("g") + ": Starting in " + delayInMs);
+                if (previousStart != start || previousDay != startDay || previousTarget != target)
+                {
+                    string delayInMs;
+                    if (remaining.Days > 0)
+                    {
+                        delayInMs = string.Format("{0}d:{1:D2}h:{2:D2}m:{3:D2}s:{4:D3}ms",
+                            remaining.Days,
+                            remaining.Hours,
+                            remaining.Minutes,
+                            remaining.Seconds,
+                            remaining.Milliseconds);
+                    }
+                    else
+                    {
+                        delayInMs = string.Format("{0:D2}h:{1:D2}m:{2:D2}s:{3:D3}ms",
+                            remaining.Hours,
+                            remaining.Minutes,
+                            remaining.Seconds,
+                            remaining.Milliseconds);
+                    }
+
+                    Console.WriteLine(now.LocalDateTime.ToString("g") + ": Starting in " + delayInMs);
                     previousStart = start;
+                    previousDay = startDay;
+                    previousTarget = target;
                 }
 
-                var msRemaining = (int)(start - now).TotalMilliseconds;
+                var delayMs = Math.Max(1d, Math.Min(remaining.TotalMilliseconds, 60_000d));
                 // Poll settings at most once per minute to pick up schedule changes
-                var delay = Math.Max(1, Math.Min(msRemaining, 60_000));
-                await Task.Delay(delay, token);
+                await _delay(TimeSpan.FromMilliseconds(delayMs), token);
             }
 
             token.ThrowIfCancellationRequested();
             return default;
+        }
+
+        private static DaySchedule? GetScheduleForDay(SonosSettings settings, DayOfWeek day)
+        {
+            if (settings.DailySchedules != null && settings.DailySchedules.TryGetValue(day, out var schedule))
+                return schedule;
+
+            return null;
+        }
+
+        private (DateTimeOffset target, DaySchedule? schedule, TimeOnly start, DayOfWeek day) DetermineNextStart(SonosSettings settings, DateTimeOffset now)
+        {
+            var today = now.DayOfWeek;
+            var todaySchedule = GetScheduleForDay(settings, today);
+            var start = todaySchedule?.StartTime ?? settings.StartTime;
+            var startDateTime = new DateTimeOffset(now.Date.Add(start.ToTimeSpan()), now.Offset);
+            var currentTime = TimeOnly.FromDateTime(now.LocalDateTime);
+
+            if (start < currentTime)
+            {
+                for (int offset = 1; offset <= 7; offset++)
+                {
+                    var day = (DayOfWeek)(((int)today + offset) % 7);
+                    var schedule = GetScheduleForDay(settings, day);
+                    var nextStart = schedule?.StartTime ?? settings.StartTime;
+                    var nextDate = new DateTimeOffset(now.Date.AddDays(offset).Add(nextStart.ToTimeSpan()), now.Offset);
+                    return (nextDate, schedule, nextStart, day);
+                }
+            }
+
+            if (start == currentTime)
+                return (startDateTime, todaySchedule, start, today);
+
+            return (startDateTime, todaySchedule, start, today);
+        }
+
+        private static Task TaskDelay(TimeSpan delay, CancellationToken token)
+        {
+            if (delay <= TimeSpan.Zero)
+                return Task.CompletedTask;
+
+            return Task.Delay(delay, token);
         }
 
         private async Task StopSpeaker(string ip, TimeOnly stopTime)


### PR DESCRIPTION
## Summary
- adjust WaitUntilStartTime to return the next occurrence when the configured start time has already passed
- ensure the service continues to use a positive timespan when waiting and respects the polling interval
- expand unit coverage to verify next-day scheduling for default and day-specific scenarios with a manual time provider

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ca7e334d748321ad478c46c5afa5a6