### PR TITLE
Ensure remember me posts explicit booleans

### DIFF
--- a/SonosControl.Web/Views/Auth/login.cshtml
+++ b/SonosControl.Web/Views/Auth/login.cshtml
@@ -97,7 +97,8 @@ Layout = null;
     </div>
 
     <div class="form-check mb-3">
-        <input id="rememberMe" name="rememberMe" type="checkbox" checked class="form-check-input" />
+        <input id="rememberMe" name="rememberMe" type="checkbox" value="true" checked class="form-check-input" />
+        <input type="hidden" name="rememberMe" value="false" />
         <label for="rememberMe" class="form-check-label">Remember Me</label>
     </div>
 


### PR DESCRIPTION
## Summary
- add explicit true value to the login page remember-me checkbox and include a hidden false fallback so form posts explicit booleans
- order the inputs so checked submissions bind to true, enabling persistent auth cookies when requested

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d0e4f369b08321b5f66960cea7ec0a