### PR TITLE
Deduplicate station lookup results

### DIFF
--- a/SonosControl.Web/Pages/StationLookup.razor
+++ b/SonosControl.Web/Pages/StationLookup.razor
@@ -1,5 +1,6 @@
 ﻿@page "/lookup"
 @using System.Net.Http.Json
+@using System.Linq
 @inject IJSRuntime JS
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @using SonosControl.Web.Data
@@ -100,6 +101,19 @@
             var http = new HttpClient();
             string apiUrl = $"https://de1.api.radio-browser.info/json/stations/search?name={Uri.EscapeDataString(searchTerm)}";
             results = await http.GetFromJsonAsync<List<RadioStation>>(apiUrl);
+
+            if (results is null)
+            {
+                results = new List<RadioStation>();
+            }
+            else
+            {
+                results = results
+                    .Where(station => station is not null && !string.IsNullOrWhiteSpace(station.Url))
+                    .GroupBy(station => NormalizeUrl(station.Url))
+                    .Select(group => group.First())
+                    .ToList();
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- ensure the station lookup results default to an empty list when the API response is null
- group fetched stations by normalized stream URL so only one entry per stream appears in the results

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d232b951748321ade4995252c749fa