### PR TITLE
Move volume control to main dashboard

### DIFF
--- a/SonosControl.Web/Pages/ConfigPage.razor
+++ b/SonosControl.Web/Pages/ConfigPage.razor
@@ -25,14 +25,6 @@
                 </div>
 
                 <div class="mb-3">
-                    <label class="form-label">🔉 Volume</label>
-                    <input type="number" class="form-control bg-secondary text-light border-0"
-                           max="100" min="1"
-                           @bind-value="Volume"
-                           @bind-value:event="oninput"/>
-                </div>
-
-                <div class="mb-3">
                     <label class="form-label">🎵 Auto Play</label>
                     <select class="form-select bg-secondary text-light border-0"
                             @bind="AutoPlaySelection" @bind:event="onchange">
@@ -299,18 +291,6 @@
           }
           await SaveSettings();
       }
-
-    private int Volume
-    {
-        get => _settings!.Volume;
-        set
-        {
-            _settings!.Volume = value;
-            _uow.ISonosConnectorRepo.SetVolume(_settings!.IP_Adress, value);
-            SaveSettings();
-            //AddLog("Volume Changed", $"Volume: {value}");
-        }
-    }
 
     private async Task OnDayChanged(DayOfWeek dayKey, object? value)
     {

--- a/SonosControl.Web/Pages/Index.razor
+++ b/SonosControl.Web/Pages/Index.razor
@@ -39,6 +39,12 @@
                                         <i class="fa fa-forward"></i>
                                     </button>
                                 }
+                                <input type="number"
+                                       class="form-control form-control-sm bg-secondary text-light border-0 me-2 volume-input"
+                                       min="0" max="100"
+                                       @bind-value="Volume"
+                                       @bind-value:event="oninput"
+                                       aria-label="Volume" />
                                 <button class="btn btn-primary" @onclick="ShuffleStation" title="Shuffle">
                                     🔀
                                 </button>
@@ -59,6 +65,12 @@
                                 <button class="btn btn-outline-light me-2" @onclick="OpenTimerModal" title="Timed playback">
                                     <i class="fa fa-clock-o"></i>
                                 </button>
+                                <input type="number"
+                                       class="form-control form-control-sm bg-secondary text-light border-0 me-2 volume-input"
+                                       min="0" max="100"
+                                       @bind-value="Volume"
+                                       @bind-value:event="oninput"
+                                       aria-label="Volume" />
                                 <button class="btn btn-primary" @onclick="ShuffleStation" title="Shuffle">
                                     🔀
                                 </button>
@@ -320,6 +332,29 @@
     private bool _isPlaying;
     private bool _isSpotifyPlaying;
     private string? spotifyUrl;
+
+    private int Volume
+    {
+        get => _settings?.Volume ?? 0;
+        set
+        {
+            if (_settings is null)
+            {
+                return;
+            }
+
+            var clamped = Math.Clamp(value, 0, 100);
+
+            if (_settings.Volume == clamped)
+            {
+                return;
+            }
+
+            _settings.Volume = clamped;
+            _ = _uow.ISonosConnectorRepo.SetVolume(_settings.IP_Adress, clamped);
+            _ = SaveSettings();
+        }
+    }
 
     private bool isAuthenticated;
     private bool isAdmin;
@@ -918,6 +953,10 @@
     .btn {
         width: 100%;
         border-radius: 5px;
+    }
+
+    .volume-input {
+        max-width: 90px;
     }
 
     .btn-danger {


### PR DESCRIPTION
## Summary
- remove the volume input from the configuration page
- expose the volume control on the main index dashboard next to the shuffle action
- persist volume updates through the existing Sonos connector

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d38b1329848321a2098dcf670b4baf