### PR TITLE
Rework playback controls layout

### DIFF
--- a/SonosControl.Web/Pages/Index.razor
+++ b/SonosControl.Web/Pages/Index.razor
@@ -21,43 +21,55 @@
                 <div class="mb-4">
                     <div class="@($"card playback-card shadow-sm border-0 rounded-4 text-white {(!_isPlaying ? "paused" : string.Empty)}")">
                         <div class="card-body">
-                            <div class="d-flex flex-column flex-lg-row align-items-start gap-4">
-                                <div class="d-flex align-items-start gap-3 flex-grow-1">
-                                    <div class="playback-icon">
-                                        <i class="fa fa-music"></i>
+                            <div class="d-flex flex-column gap-3">
+                                <div class="d-flex flex-column flex-lg-row align-items-start gap-3">
+                                    <div class="d-flex align-items-start gap-3 flex-grow-1">
+                                        <div class="playback-icon">
+                                            <i class="fa fa-music"></i>
+                                        </div>
+                                        <div class="playback-text">
+                                            <h5 class="mb-1">@(_isPlaying ? "Now Playing" : "Playback Paused")</h5>
+                                            <p class="mb-0">@(_isPlaying ? "Click to pause playback." : "Click to start playing music.")</p>
+                                        </div>
                                     </div>
-                                    <div class="playback-text">
-                                        <h5 class="mb-1">@(_isPlaying ? "Now Playing" : "Playback Paused")</h5>
-                                        <p class="mb-0">@(_isPlaying ? "Click to pause playback." : "Click to start playing music.")</p>
+                                    @{
+                                        var playbackToggleLabel = _isPlaying ? "Pause playback" : "Start playback";
+                                    }
+                                    <div class="playback-actions d-flex align-items-center flex-wrap gap-2 ms-auto">
+                                        <button class="btn btn-light text-dark playback-action"
+                                                @onclick="() => Play(!_isPlaying)"
+                                                title="@playbackToggleLabel"
+                                                aria-label="@playbackToggleLabel">
+                                            <i class="fa @(_isPlaying ? "fa-pause" : "fa-play")"></i>
+                                        </button>
+                                        <button class="btn btn-outline-light playback-action"
+                                                @onclick="OpenTimerModal"
+                                                title="Schedule playback"
+                                                aria-label="Schedule playback">
+                                            <i class="fa fa-clock-o"></i>
+                                        </button>
+                                        @if (_isPlaying && _isSpotifyPlaying)
+                                        {
+                                            <button class="btn btn-outline-light playback-action"
+                                                    @onclick="NextTrack"
+                                                    title="Skip track"
+                                                    aria-label="Skip track">
+                                                <i class="fa fa-forward"></i>
+                                            </button>
+                                        }
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-                    }
-                    else
-                    {
-                        <div class="alert alert-warning d-flex justify-content-between align-items-center">
-                            <div>
-                                <strong>Playback Paused</strong>
-                                <p class="mb-0 text-light-emphasis">Click to start playing music.</p>
-                            </div>
-                            <div class="playback-actions d-flex align-items-center flex-wrap justify-content-end gap-2">
-                                <button class="btn btn-success" @onclick="() => Play(true)">
-                                    <i class="fa fa-play"></i>
-                                </button>
-                                <button class="btn btn-outline-light" @onclick="OpenTimerModal" title="Timed playback">
-                                    <i class="fa fa-clock-o"></i>
-                                </button>
-                                <div class="volume-control bg-secondary text-light rounded-pill d-flex align-items-center">
-                                    <i class="fa fa-volume-up text-light-emphasis"></i>
-                                    <input type="range"
-                                           class="form-range volume-slider"
-                                           min="0" max="100"
-                                           @bind-value="Volume"
-                                           @bind-value:event="oninput"
-                                           aria-label="Volume" />
-                                    <span class="volume-value">@($"{Volume}%")</span>
-
+                                <div class="d-flex justify-content-end">
+                                    <div class="playback-volume-control">
+                                        <i class="fa fa-volume-up"></i>
+                                        <input type="range"
+                                               class="form-range playback-volume-slider"
+                                               min="0" max="100"
+                                               @bind-value="Volume"
+                                               @bind-value:event="oninput"
+                                               aria-label="Volume" />
+                                        <span class="playback-volume-value">@($"{Volume}%")</span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -1004,6 +1016,10 @@
         box-shadow: 0 0.6rem 1.2rem rgba(0, 0, 0, 0.25);
     }
 
+    .playback-actions {
+        justify-content: flex-end;
+    }
+
     .playback-action:hover,
     .playback-action:focus {
         transform: translateY(-1px);
@@ -1013,6 +1029,8 @@
     .playback-volume-control {
         display: inline-flex;
         align-items: center;
+        justify-content: flex-end;
+        flex-wrap: wrap;
         gap: 0.65rem;
         padding: 0.45rem 0.9rem;
         border-radius: 999px;


### PR DESCRIPTION
## Summary
- replace the playback status markup with a single gradient card that keeps the text on the left, the playback controls on the top-right, and the volume slider anchored to the bottom-right
- surface a Spotify skip control when playback is active and the current source is Spotify while reusing a computed label for the play/pause toggle
- tweak the playback styling so the action buttons and volume slider stay aligned when the layout wraps

## Testing
- `dotnet build` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d8a4b35c8321836ec875a73933c0