### PR TITLE
Restrict config navigation to admins

### DIFF
--- a/SonosControl.Web/Shared/NavMenu.razor
+++ b/SonosControl.Web/Shared/NavMenu.razor
@@ -19,11 +19,15 @@
                 <span class="oi oi-magnifying-glass" aria-hidden="true"></span> Station Lookup
             </NavLink>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="config">
-                <span class="oi oi-cog" aria-hidden="true"></span> Sonos Config
-            </NavLink>
-        </div>
+        <AuthorizeView Roles="admin,superadmin">
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="config">
+                        <span class="oi oi-cog" aria-hidden="true"></span> Sonos Config
+                    </NavLink>
+                </div>
+            </Authorized>
+        </AuthorizeView>
         <AuthorizeView Roles="admin,superadmin">
             <Authorized>
                 <div class="nav-item px-3">


### PR DESCRIPTION
## Summary
- wrap the Sonos Config navigation item in an authorize view so only admins and superadmins see it

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e0eec3608321a61d8f59d0ab6c2d