### PR TITLE
Document Sonos TuneIn and Spotify setup prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ The engine polls settings at most once per minute, reacts instantly to near-term
 - **TuneIn & Internet Radio:** Store any stream URL, or fetch new stations directly from Radio Browser.
 - **Localization:** Built-in support for `en-US` and `de-AT` cultures.
 
+> **Important:** Set up TuneIn and Spotify inside the official Sonos app before using those features in SonosControl. The dashboard relies on Sonos’s native integrations, so the services must already be linked in your Sonos account.
+
 ---
 
 ## Logging & Observability


### PR DESCRIPTION
## Summary
- note that TuneIn and Spotify must be configured in the official Sonos app before those SonosControl integrations can operate

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68d3e20eb4888321958112e41899e2a6