### PR TITLE
Add configurable max volume and playback gradient settings

### DIFF
--- a/SonosControl.DAL/Models/SonosSettings.cs
+++ b/SonosControl.DAL/Models/SonosSettings.cs
@@ -4,7 +4,12 @@ namespace SonosControl.DAL.Models
 {
     public class SonosSettings
     {
+        public const string DefaultNowPlayingGradientStartColor = "#0f172a";
+        public const string DefaultNowPlayingGradientMidColor = "#1e3a8a";
+        public const string DefaultNowPlayingGradientEndColor = "#0f766e";
+
         public int Volume { get; set; } = 10;
+        public int MaxVolume { get; set; } = 100;
         public TimeOnly StartTime { get; set; } = new TimeOnly(6, 0);
         public TimeOnly StopTime { get; set; } = new TimeOnly(18, 0);
         public string IP_Adress { get; set; } = "10.0.0.0";
@@ -33,5 +38,9 @@ namespace SonosControl.DAL.Models
         public List<DayOfWeek> ActiveDays { get; set; } = new();
 
         public bool AllowUserRegistration { get; set; } = true;
+
+        public string NowPlayingGradientStartColor { get; set; } = DefaultNowPlayingGradientStartColor;
+        public string NowPlayingGradientMidColor { get; set; } = DefaultNowPlayingGradientMidColor;
+        public string NowPlayingGradientEndColor { get; set; } = DefaultNowPlayingGradientEndColor;
     }
 }

--- a/SonosControl.Web/Data/config.json
+++ b/SonosControl.Web/Data/config.json
@@ -1,1 +1,62 @@
-{"Volume":18,"StartTime":"06:45:00","StopTime":"17:30:00","IP_Adress":"10.1.12.251","Stations":[{"Name":"Antenne Vorarlberg","Url":"web.radio.antennevorarlberg.at/av-live/stream/mp3"},{"Name":"Radio V","Url":"orf-live.ors-shoutcast.at/vbg-q2a"},{"Name":"Kronehit","Url":"onair.krone.at/kronehit.mp3"},{"Name":"Ö3","Url":"orf-live.ors-shoutcast.at/oe3-q2a"},{"Name":"Radio Paloma","Url":"www3.radiopaloma.de/RP-Hauptkanal.pls"},{"Name":"365 days christmas","Url":"us3.streamingpulse.com/ssl/7038"},{"Name":"Brainrot FM","Url":"stream.zeno.fm/95ylfdydc8nvv"},{"Name":"Rock Antenne","Url":"stream.rockantenne.de/rockantenne/stream/mp3"}],"SpotifyTracks":[{"Name":"Top 50 Global","Url":"https://open.spotify.com/playlist/37i9dQZEVXbMDoHDwVN2tF"},{"Name":"Astroworld","Url":"https://open.spotify.com/album/41GuZcammIkupMPKH2OJ6I"}],"ActiveDays":[1,2,3,4,5],"AllowUserRegistration":true}
+{
+  "Volume": 18,
+  "MaxVolume": 100,
+  "StartTime": "06:45:00",
+  "StopTime": "17:30:00",
+  "IP_Adress": "10.1.12.251",
+  "Stations": [
+    {
+      "Name": "Antenne Vorarlberg",
+      "Url": "web.radio.antennevorarlberg.at/av-live/stream/mp3"
+    },
+    {
+      "Name": "Radio V",
+      "Url": "orf-live.ors-shoutcast.at/vbg-q2a"
+    },
+    {
+      "Name": "Kronehit",
+      "Url": "onair.krone.at/kronehit.mp3"
+    },
+    {
+      "Name": "\u00d63",
+      "Url": "orf-live.ors-shoutcast.at/oe3-q2a"
+    },
+    {
+      "Name": "Radio Paloma",
+      "Url": "www3.radiopaloma.de/RP-Hauptkanal.pls"
+    },
+    {
+      "Name": "365 days christmas",
+      "Url": "us3.streamingpulse.com/ssl/7038"
+    },
+    {
+      "Name": "Brainrot FM",
+      "Url": "stream.zeno.fm/95ylfdydc8nvv"
+    },
+    {
+      "Name": "Rock Antenne",
+      "Url": "stream.rockantenne.de/rockantenne/stream/mp3"
+    }
+  ],
+  "SpotifyTracks": [
+    {
+      "Name": "Top 50 Global",
+      "Url": "https://open.spotify.com/playlist/37i9dQZEVXbMDoHDwVN2tF"
+    },
+    {
+      "Name": "Astroworld",
+      "Url": "https://open.spotify.com/album/41GuZcammIkupMPKH2OJ6I"
+    }
+  ],
+  "ActiveDays": [
+    1,
+    2,
+    3,
+    4,
+    5
+  ],
+  "AllowUserRegistration": true,
+  "NowPlayingGradientStartColor": "#0f172a",
+  "NowPlayingGradientMidColor": "#1e3a8a",
+  "NowPlayingGradientEndColor": "#0f766e"
+}

--- a/SonosControl.Web/Pages/ConfigPage.razor
+++ b/SonosControl.Web/Pages/ConfigPage.razor
@@ -47,6 +47,42 @@
                 </div>
 
                 <div class="mb-3">
+                    <label class="form-label">🔊 Max Volume</label>
+                    <input type="number" class="form-control bg-secondary text-light border-0"
+                           min="0" max="100"
+                           @bind-value="MaxVolume"
+                           @bind-value:event="oninput" />
+                    <div class="form-text text-light text-opacity-75">
+                        Limits the highest volume that can be set from the main control panel.
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">🎨 Now Playing Gradient</label>
+                    <div class="gradient-inputs d-flex flex-wrap gap-3">
+                        <div class="gradient-input text-center">
+                            <span class="text-uppercase small text-muted d-block">Start</span>
+                            <input type="color" class="form-control form-control-color"
+                                   @bind-value="GradientStartColor"
+                                   @bind-value:event="oninput" />
+                        </div>
+                        <div class="gradient-input text-center">
+                            <span class="text-uppercase small text-muted d-block">Middle</span>
+                            <input type="color" class="form-control form-control-color"
+                                   @bind-value="GradientMidColor"
+                                   @bind-value:event="oninput" />
+                        </div>
+                        <div class="gradient-input text-center">
+                            <span class="text-uppercase small text-muted d-block">End</span>
+                            <input type="color" class="form-control form-control-color"
+                                   @bind-value="GradientEndColor"
+                                   @bind-value:event="oninput" />
+                        </div>
+                    </div>
+                    <div class="gradient-preview mt-3" style="@GradientPreviewStyle"></div>
+                </div>
+
+                <div class="mb-3">
                     <label class="form-label">⏰ Start Time</label>
                     <input type="time" class="form-control bg-secondary text-light border-0"
                            @bind-value="StartTime"
@@ -245,12 +281,99 @@
           }
       }
 
+    private int MaxVolume
+    {
+        get => Math.Clamp(_settings?.MaxVolume ?? 100, 0, 100);
+        set
+        {
+            if (_settings is null)
+                return;
+
+            var clamped = Math.Clamp(value, 0, 100);
+
+            if (_settings.MaxVolume == clamped)
+                return;
+
+            _settings.MaxVolume = clamped;
+
+            if (_settings.Volume > clamped)
+            {
+                _settings.Volume = clamped;
+            }
+
+            SaveSettings();
+            _ = AddLog("Max Volume Changed", $"Value: {clamped}");
+        }
+    }
+
+    private string GradientStartColor
+    {
+        get => NormalizeColor(_settings?.NowPlayingGradientStartColor, SonosSettings.DefaultNowPlayingGradientStartColor);
+        set
+        {
+            if (_settings is null)
+                return;
+
+            var normalized = NormalizeColor(value, SonosSettings.DefaultNowPlayingGradientStartColor);
+
+            if (_settings.NowPlayingGradientStartColor == normalized)
+                return;
+
+            _settings.NowPlayingGradientStartColor = normalized;
+            SaveSettings();
+        }
+    }
+
+    private string GradientMidColor
+    {
+        get => NormalizeColor(_settings?.NowPlayingGradientMidColor, SonosSettings.DefaultNowPlayingGradientMidColor);
+        set
+        {
+            if (_settings is null)
+                return;
+
+            var normalized = NormalizeColor(value, SonosSettings.DefaultNowPlayingGradientMidColor);
+
+            if (_settings.NowPlayingGradientMidColor == normalized)
+                return;
+
+            _settings.NowPlayingGradientMidColor = normalized;
+            SaveSettings();
+        }
+    }
+
+    private string GradientEndColor
+    {
+        get => NormalizeColor(_settings?.NowPlayingGradientEndColor, SonosSettings.DefaultNowPlayingGradientEndColor);
+        set
+        {
+            if (_settings is null)
+                return;
+
+            var normalized = NormalizeColor(value, SonosSettings.DefaultNowPlayingGradientEndColor);
+
+            if (_settings.NowPlayingGradientEndColor == normalized)
+                return;
+
+            _settings.NowPlayingGradientEndColor = normalized;
+            SaveSettings();
+        }
+    }
+
+    private string GradientPreviewStyle => $"background: linear-gradient(135deg, {GradientStartColor} 0%, {GradientMidColor} 55%, {GradientEndColor} 100%);";
+
     private async Task SaveSettings()
     {
         _settings.ActiveDays = DaySelection
             .Where(kv => kv.Value)
             .Select(kv => kv.Key)
             .ToList();
+
+        _settings.MaxVolume = Math.Clamp(_settings.MaxVolume, 0, 100);
+        _settings.Volume = Math.Clamp(_settings.Volume, 0, _settings.MaxVolume);
+        _settings.NowPlayingGradientStartColor = NormalizeColor(_settings.NowPlayingGradientStartColor, SonosSettings.DefaultNowPlayingGradientStartColor);
+        _settings.NowPlayingGradientMidColor = NormalizeColor(_settings.NowPlayingGradientMidColor, SonosSettings.DefaultNowPlayingGradientMidColor);
+        _settings.NowPlayingGradientEndColor = NormalizeColor(_settings.NowPlayingGradientEndColor, SonosSettings.DefaultNowPlayingGradientEndColor);
 
         await _uow.ISettingsRepo.WriteSettings(_settings!);
     }
@@ -298,6 +421,38 @@
         DaySelection[dayKey] = isChecked;
 
         await SaveSettings();
+    }
+
+    private static string NormalizeColor(string? value, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        var trimmed = value.Trim();
+
+        if (!trimmed.StartsWith("#", System.StringComparison.Ordinal))
+        {
+            trimmed = $"#{trimmed.TrimStart('#')}";
+        }
+
+        if (trimmed.Length == 7)
+        {
+            return trimmed;
+        }
+
+        if (trimmed.Length == 4)
+        {
+            return $"#{trimmed[1]}{trimmed[1]}{trimmed[2]}{trimmed[2]}{trimmed[3]}{trimmed[3]}";
+        }
+
+        if (trimmed.Length > 7)
+        {
+            return trimmed.Substring(0, 7);
+        }
+
+        return fallback;
     }
 
 
@@ -423,6 +578,26 @@
         padding: 0.45rem;
         font-weight: 500;
         white-space: nowrap;
+    }
+
+    .gradient-inputs .form-control-color {
+        width: 3rem;
+        height: 3rem;
+        padding: 0;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+    }
+
+    .gradient-input span {
+        letter-spacing: 0.05em;
+    }
+
+    .gradient-preview {
+        height: 2.5rem;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.35);
     }
 
 

--- a/SonosControl.Web/Pages/Index.razor
+++ b/SonosControl.Web/Pages/Index.razor
@@ -19,7 +19,7 @@
 
                 <!-- Playback Status -->
                 <div class="mb-4">
-                    <div class="@($"card playback-card shadow-sm border-0 rounded-4 text-white {(!_isPlaying ? "paused" : string.Empty)}")">
+                    <div class="@($"card playback-card shadow-sm border-0 rounded-4 text-white {(!_isPlaying ? "paused" : string.Empty)}")" style="@PlaybackCardStyle">
                         <div class="card-body">
                             <div class="d-flex flex-column gap-3">
                                 <div class="d-flex flex-column flex-lg-row align-items-start gap-3">
@@ -64,7 +64,7 @@
                                         <i class="fa fa-volume-up"></i>
                                         <input type="range"
                                                class="form-range playback-volume-slider"
-                                               min="0" max="100"
+                                               min="0" max="@MaxVolumeLimit"
                                                @bind-value="Volume"
                                                @bind-value:event="oninput"
                                                aria-label="Volume" />
@@ -342,7 +342,16 @@
 
     private int Volume
     {
-        get => _settings?.Volume ?? 0;
+        get
+        {
+            if (_settings is null)
+            {
+                return 0;
+            }
+
+            var limit = MaxVolumeLimit;
+            return Math.Min(_settings.Volume, limit);
+        }
         set
         {
             if (_settings is null)
@@ -350,7 +359,8 @@
                 return;
             }
 
-            var clamped = Math.Clamp(value, 0, 100);
+            var limit = MaxVolumeLimit;
+            var clamped = Math.Clamp(value, 0, limit);
 
             if (_settings.Volume == clamped)
             {
@@ -362,6 +372,12 @@
             _ = SaveSettings();
         }
     }
+
+    private int MaxVolumeLimit => Math.Clamp(_settings?.MaxVolume ?? 100, 0, 100);
+
+    private string? PlaybackCardStyle => !_isPlaying || _settings is null
+        ? null
+        : $"background: linear-gradient(135deg, {NormalizeColor(_settings.NowPlayingGradientStartColor, SonosSettings.DefaultNowPlayingGradientStartColor)} 0%, {NormalizeColor(_settings.NowPlayingGradientMidColor, SonosSettings.DefaultNowPlayingGradientMidColor)} 55%, {NormalizeColor(_settings.NowPlayingGradientEndColor, SonosSettings.DefaultNowPlayingGradientEndColor)} 100%);";
 
     private bool isAuthenticated;
     private bool isAdmin;
@@ -720,6 +736,38 @@
         timerErrorMessage = null;
     }
 
+    private static string NormalizeColor(string? value, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        var trimmed = value.Trim();
+
+        if (!trimmed.StartsWith("#", System.StringComparison.Ordinal))
+        {
+            trimmed = $"#{trimmed.TrimStart('#')}";
+        }
+
+        if (trimmed.Length == 7)
+        {
+            return trimmed;
+        }
+
+        if (trimmed.Length == 4)
+        {
+            return $"#{trimmed[1]}{trimmed[1]}{trimmed[2]}{trimmed[2]}{trimmed[3]}{trimmed[3]}";
+        }
+
+        if (trimmed.Length > 7)
+        {
+            return trimmed.Substring(0, 7);
+        }
+
+        return fallback;
+    }
+
     private async Task AddLog(string action, string? details = null)
     {
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
@@ -763,6 +811,14 @@
             return;
 
         _settings!.Volume = await _uow.ISonosConnectorRepo.GetVolume(_settings!.IP_Adress);
+
+        var maxVolumeLimit = MaxVolumeLimit;
+        if (_settings.Volume > maxVolumeLimit)
+        {
+            _settings.Volume = maxVolumeLimit;
+            await _uow.ISonosConnectorRepo.SetVolume(_settings.IP_Adress, maxVolumeLimit);
+        }
+
         await SaveSettings();
         _isPlaying = await IsPlaying();
         _stationUpdateTimer = new Timer(async _ => await LoadCurrentStation(), null, 0, 1000);


### PR DESCRIPTION
## Summary
- add a maximum volume cap and configurable now-playing gradient colors to the shared Sonos settings model
- expose max volume and gradient color pickers with live preview on the configuration page and persist sanitized values
- honor the configured max volume and gradient styling on the control panel and update the bundled config.json defaults

## Testing
- `dotnet test` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e343d8b88321b8eaf9d45db95c90