### PR TITLE
Add Sonos reboot control from configuration page

### DIFF
--- a/SonosControl.DAL/Interfaces/ISonosConnectorRepo.cs
+++ b/SonosControl.DAL/Interfaces/ISonosConnectorRepo.cs
@@ -21,5 +21,6 @@ namespace SonosControl.DAL.Interfaces
         Task<List<string>> GetQueue(string ip, CancellationToken cancellationToken = default);
         Task PreviousTrack(string ip, CancellationToken cancellationToken = default);
         Task NextTrack(string ip, CancellationToken cancellationToken = default);
+        Task RebootDeviceAsync(string ip, CancellationToken cancellationToken = default);
     }
 }

--- a/SonosControl.DAL/Repos/SonosConnectorRepo.cs
+++ b/SonosControl.DAL/Repos/SonosConnectorRepo.cs
@@ -582,6 +582,20 @@ namespace SonosControl.DAL.Repos
             await SendAvTransportCommand(ip, "Next", cancellationToken);
         }
 
+        public async Task RebootDeviceAsync(string ip, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(ip))
+            {
+                throw new ArgumentException("IP address must be provided.", nameof(ip));
+            }
+
+            var client = CreateClient();
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"http://{ip}:1400/reboot");
+            using var response = await client.SendAsync(request, cancellationToken);
+            response.EnsureSuccessStatusCode();
+        }
+
         private async Task SendAvTransportCommand(string ip, string action, CancellationToken cancellationToken)
         {
             var url = $"http://{ip}:1400/MediaRenderer/AVTransport/Control";

--- a/SonosControl.Tests/SonosConnectorRepoTests.cs
+++ b/SonosControl.Tests/SonosConnectorRepoTests.cs
@@ -195,4 +195,19 @@ public class SonosConnectorRepoTests
         Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
         Assert.Equal(0, repo.StartPlayingCallCount);
     }
+
+    [Fact]
+    public async Task RebootDeviceAsync_PostsToRebootEndpoint()
+    {
+        var handler = new QueueHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = new HttpClient(handler);
+        var repo = new SonosConnectorRepo(new TestHttpClientFactory(client));
+
+        await repo.RebootDeviceAsync("1.2.3.4");
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("http://1.2.3.4:1400/reboot", request.Uri!.ToString());
+    }
 }

--- a/SonosControl.Web/Pages/ConfigPage.razor
+++ b/SonosControl.Web/Pages/ConfigPage.razor
@@ -25,6 +25,23 @@
                 </div>
 
                 <div class="mb-3">
+                    <label class="form-label d-block">⚙️ Device Actions</label>
+                    <button class="btn btn-outline-warning"
+                            @onclick="SendRebootCommand"
+                            disabled="@(_isRebooting || string.IsNullOrWhiteSpace(_settings?.IP_Adress))">
+                        @if (_isRebooting)
+                        {
+                            <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                        }
+                        Reboot Speaker
+                    </button>
+                    @if (!string.IsNullOrEmpty(_rebootAlertMessage))
+                    {
+                        <div class="alert @_rebootAlertCss mt-2 mb-0">@_rebootAlertMessage</div>
+                    }
+                </div>
+
+                <div class="mb-3">
                     <label class="form-label">🎵 Auto Play</label>
                     <select class="form-select bg-secondary text-light border-0"
                             @bind="AutoPlaySelection" @bind:event="onchange">
@@ -186,6 +203,9 @@
     private TimeOnly TimeRightNow = TimeOnly.FromDateTime(DateTime.Now);
     private Dictionary<DayOfWeek, bool> DaySelection = new();
     private bool canEditIp;
+    private bool _isRebooting;
+    private string? _rebootAlertMessage;
+    private string _rebootAlertCss = "alert-info";
 
 
     protected override async Task OnInitializedAsync()
@@ -467,6 +487,48 @@
             _settings!.IP_Adress = value;
             SaveSettings();
             AddLog("IP-Adress Changed", $"IP: {value}");
+        }
+    }
+
+    private async Task SendRebootCommand()
+    {
+        if (_settings is null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_settings.IP_Adress))
+        {
+            _rebootAlertCss = "alert-warning";
+            _rebootAlertMessage = "Set a valid IP address before sending commands.";
+            return;
+        }
+
+        _isRebooting = true;
+        _rebootAlertMessage = null;
+
+        try
+        {
+            await _uow.ISonosConnectorRepo.RebootDeviceAsync(_settings.IP_Adress);
+            _rebootAlertCss = "alert-success";
+            _rebootAlertMessage = "Reboot command sent to the speaker.";
+            await AddLog("Reboot Command Sent", $"IP: {_settings.IP_Adress}");
+        }
+        catch (Exception ex)
+        {
+            _rebootAlertCss = "alert-danger";
+            _rebootAlertMessage = $"Failed to send reboot command: {ex.Message}";
+            try
+            {
+                await AddLog("Reboot Command Failed", $"IP: {_settings.IP_Adress}; Error: {ex.Message}");
+            }
+            catch
+            {
+            }
+        }
+        finally
+        {
+            _isRebooting = false;
         }
     }
 


### PR DESCRIPTION
## Summary
- add a reboot action to the configuration page so admins can trigger a speaker restart
- expose the reboot command through the Sonos connector interface and implementation
- cover the reboot endpoint with a unit test

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dffe43a24083219c197bd7077b463a