### PR TITLE
🎨 Palette: Improve navigation accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-12 - MVC View Form Feedback
 **Learning:** Standard ASP.NET MVC Views cannot rely on Blazor's `@onclick` state management. For simple form submissions like Login, vanilla JavaScript `submit` event listeners are the most robust way to provide immediate feedback (loading spinner, disabled state) without needing complex frontend frameworks.
 **Action:** Use simple script injection for loading states on MVC Views (like Login/Logout) to improve perceived performance and prevent double-submit.
+
+## 2026-06-15 - Hamburger Menu Accessibility
+**Learning:** Collapsible navigation menus ("hamburger menus") often lack state information. Screen reader users can find the button but don't know if the menu is open or closed, or what it controls.
+**Action:** Always add `aria-expanded` (linked to state), `aria-label="Toggle navigation"`, and `aria-controls="[menu-container-id]"` to the toggle button.

--- a/SonosControl.Web/Shared/MainLayout.razor
+++ b/SonosControl.Web/Shared/MainLayout.razor
@@ -52,7 +52,7 @@
                             <button type="submit" class="btn btn-sm btn-danger">Logout</button>
                         </form>
 
-                        <a href="@($"/useredit")" class="top-link top-link--icon">
+                        <a href="@($"/useredit")" class="top-link top-link--icon" aria-label="User settings">
                             <span class="oi oi-person" aria-hidden="true"></span>
                         </a>
                     }

--- a/SonosControl.Web/Shared/NavMenu.razor
+++ b/SonosControl.Web/Shared/NavMenu.razor
@@ -18,12 +18,12 @@
             <span class="nav-brand-title">SonosControl</span>
             <span class="nav-brand-subtitle">Command center</span>
         </div>
-        <button title="Navigation menu" class="navbar-toggler nav-toggler" @onclick="ToggleNavMenu">
+        <button title="Navigation menu" class="navbar-toggler nav-toggler" @onclick="ToggleNavMenu" aria-label="Toggle navigation" aria-expanded="@(!collapseNavMenu)" aria-controls="nav-menu-container">
             <span class="navbar-toggler-icon"></span>
         </button>
     </div>
 
-    <div class="@NavMenuCssClass nav-scrollable px-3">
+    <div id="nav-menu-container" class="@NavMenuCssClass nav-scrollable px-3">
         <nav class="nav-links" @onclick="ToggleNavMenu">
             <div class="nav-item">
                 <NavLink class="nav-link" href="" Match="NavLinkMatch.All">


### PR DESCRIPTION
Improved navigation accessibility by adding ARIA attributes to the mobile menu toggle and the user profile link.

### Changes
- **NavMenu.razor**: Added `aria-label`, `aria-expanded`, and `aria-controls` to the hamburger button. Added `id` to the menu container.
- **MainLayout.razor**: Added `aria-label="User settings"` to the icon-only profile link.

### Accessibility
- Screen readers will now announce the state of the mobile menu (expanded/collapsed).
- The user profile link now has an accessible name.

---
*PR created automatically by Jules for task [2875494098663588741](https://jules.google.com/task/2875494098663588741) started by @Darkatek7*