### PR TITLE
Restructure home into Stage layout with player-first hierarchy

### DIFF
--- a/SonosControl.Web/Pages/IndexPage.razor
+++ b/SonosControl.Web/Pages/IndexPage.razor
@@ -25,8 +25,8 @@
 
 @if (_settings is not null)
 {
-    <div class="home-dashboard-shell">
-        <section class="home-ops-dashboard" data-qa="home-operations-dashboard" aria-labelledby="home-ops-heading">
+    <div class="stage-shell">
+        <section class="home-ops-dashboard stage" data-qa="home-operations-dashboard" aria-labelledby="home-ops-heading">
             @{
                 var nowLocal = DateTimeOffset.Now;
                 var activeWindow = ScheduleWindowEvaluator.SelectActiveWindow(_settings.ScheduleWindows, nowLocal);
@@ -36,13 +36,13 @@
                 var libraryItems = GetActiveLibrarySources().ToList();
                 var recentActivity = GetRecentActivity().ToList();
             }
-            <header class="home-ops-dashboard__header">
-                <div>
-                    <span class="spotify-eyebrow">Operations</span>
-                    <h1 id="home-ops-heading">Today at a glance</h1>
-                    <p>Live playback, automation, device health, queue state, and compact source control.</p>
+
+            <header class="stage-masthead">
+                <div class="stage-masthead__copy">
+                    <span class="stage-eyebrow">@(activeWindow is null ? "Manual session" : "Automation live")</span>
+                    <h1 id="home-ops-heading">Listen now</h1>
                 </div>
-                <div class="home-ops-dashboard__status">
+                <div class="stage-masthead__meta">
                     <span class="home-ops-status-pill @(activeWindow is null ? "is-idle" : "is-active")">
                         @(activeWindow is null ? "Manual control" : "Automation running")
                     </span>
@@ -50,105 +50,159 @@
                 </div>
             </header>
 
-            @if (_settings.Speakers.Any())
-            {
-                <div class="home-ops-control-strip" aria-label="Playback controls">
-                    <div class="home-ops-control-strip__room">
-                        <label for="activeSpeakerSelect">Active room</label>
-                        <select id="activeSpeakerSelect" class="form-select" @bind="SelectedSpeakerIp">
-                            @foreach (var speaker in _settings.Speakers)
-                            {
-                                <option value="@speaker.IpAddress">@speaker.Name</option>
-                            }
-                        </select>
-                    </div>
-                    <div class="home-ops-control-strip__actions">
-                        <div class="btn-group">
-                            <button class="btn btn-outline-primary" @onclick="OpenGroupModal" disabled="@(_isGrouping || _isUngrouping)" title="Group speakers">
-                                @if (_isGrouping)
-                                {
-                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                                }
-                                else
-                                {
-                                    <Icon Name="link" Size="16" /> <span>Group</span>
-                                }
-                            </button>
-                            <button class="btn btn-outline-secondary home-ops-icon-button" @onclick="UngroupCurrent" disabled="@(_isGrouping || _isUngrouping)" title="Ungroup active speaker" aria-label="Ungroup active speaker">
-                                @if (_isUngrouping)
-                                {
-                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                                }
-                                else
-                                {
-                                    <Icon Name="unlink" Size="16" />
-                                }
-                            </button>
+            <section class="stage-hero" aria-label="Now playing">
+                <div class="stage-hero__backdrop" aria-hidden="true"></div>
+                <div class="stage-hero__main">
+                    @if (!string.IsNullOrWhiteSpace(currentTrackArtUrl))
+                    {
+                        <img src="@currentTrackArtUrl" alt="@($"Album art for {currentlyPlaying}")" class="home-ops-now__art stage-hero__art" />
+                    }
+                    else
+                    {
+                        <div class="home-ops-now__art home-ops-now__art--placeholder stage-hero__art" aria-hidden="true">
+                            <Icon Name="music" Size="44" />
                         </div>
-                        <button class="btn btn-outline-primary home-ops-sync-button" data-qa="home-dashboard-sync" @onclick="HandleSyncPlay" disabled="@PlaybackState.IsSyncing" title="Play current media on all speakers">
-                            @if (PlaybackState.IsSyncing)
-                            {
-                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                                <span class="visually-hidden">Syncing...</span>
-                            }
-                            else
-                            {
+                    }
+                    <div class="stage-hero__meta">
+                        <span class="stage-hero__context">@GetSelectedSpeakerName() · @(_isPlaying ? "Playing" : "Paused")</span>
+                        <h2 class="stage-hero__title" title="@currentlyPlaying">@currentlyPlaying</h2>
+                        <p class="stage-hero__station" title="@currentStationDisplay">@currentStationDisplay</p>
+                        <div class="stage-transport" aria-label="Playback controls">
+                            <button type="button" class="stage-transport__button" @onclick="HandleQueueRefresh" title="Refresh queue" aria-label="Refresh queue">
                                 <Icon Name="refresh" Size="16" />
-                                <span>Sync Play</span>
-                            }
-                        </button>
-                        <button type="button" class="btn btn-primary home-ops-main-play" @onclick="() => Play(!_isPlaying)" disabled="@_isMainPlaybackLoading" aria-label="@(_isPlaying ? "Pause playback" : "Start playback")">
-                            @if (_isMainPlaybackLoading)
-                            {
-                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                            }
-                            else
-                            {
-                                <Icon Name="@(_isPlaying ? "pause" : "play")" Size="16" />
-                                <span>@(_isPlaying ? "Pause" : "Play")</span>
-                            }
-                        </button>
-                        <button type="button" class="btn btn-outline-primary" @onclick="OpenTimerModal">
-                            <Icon Name="timer" Size="16" /> Timer
-                        </button>
-                    </div>
-                    <div class="home-ops-control-strip__direct">
-                        <label for="homeDirectMediaUrl">Direct URL Play</label>
-                        <div class="home-ops-direct-play">
-                            <input id="homeDirectMediaUrl"
-                                   type="url"
-                                   class="form-control"
-                                   @bind-value="_directMediaUrl"
-                                   @bind-value:event="oninput"
-                                   placeholder="https://..."
-                                   aria-label="Direct media URL" />
-                            <button type="button"
-                                    class="btn btn-primary"
-                                    @onclick="PlayDirectMediaUrl"
-                                    disabled="@(_isDirectUrlLoading || string.IsNullOrWhiteSpace(_directMediaUrl))"
-                                    aria-label="Play direct URL">
-                                @if (_isDirectUrlLoading)
+                            </button>
+                            <button type="button" class="stage-transport__play" @onclick="() => Play(!_isPlaying)" disabled="@_isMainPlaybackLoading" aria-label="@(_isPlaying ? "Pause playback" : "Start playback")">
+                                @if (_isMainPlaybackLoading)
                                 {
                                     <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
                                 }
                                 else
                                 {
-                                    <Icon Name="play" Size="14" />
-                                    <span>Play</span>
+                                    <Icon Name="@(_isPlaying ? "pause" : "play")" Size="22" />
                                 }
                             </button>
-                            <button type="button"
-                                    class="btn btn-outline-primary"
-                                    @onclick="OpenDirectUrlSaveModal"
-                                    disabled="@(_isDirectUrlLoading || string.IsNullOrWhiteSpace(_directMediaUrl))"
-                                    aria-label="Save direct URL">
-                                <Icon Name="plus" Size="14" />
-                                <span>Save</span>
+                            <button type="button" class="stage-transport__button" @onclick="NextTrack" disabled="@(!CanSkipToNextTrack() || _isNextTrackLoading)" title="Next track" aria-label="Next track">
+                                <Icon Name="forward" Size="16" />
                             </button>
+                            <span class="stage-transport__divider" aria-hidden="true"></span>
+                            <button type="button" class="stage-transport__chip home-ops-sync-button" data-qa="home-dashboard-sync" @onclick="HandleSyncPlay" disabled="@PlaybackState.IsSyncing" title="Play current media on all speakers">
+                                @if (PlaybackState.IsSyncing)
+                                {
+                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                    <span class="visually-hidden">Syncing...</span>
+                                }
+                                else
+                                {
+                                    <Icon Name="refresh" Size="14" />
+                                    <span>Sync</span>
+                                }
+                            </button>
+                            <button type="button" class="stage-transport__chip" @onclick="OpenTimerModal">
+                                <Icon Name="timer" Size="14" />
+                                <span>Timer</span>
+                            </button>
+                            @if (_timerEndTimeUtc is not null)
+                            {
+                                var localStopTime = _timerEndTimeUtc.Value.ToLocalTime();
+                                <button type="button" class="stage-transport__chip stage-transport__chip--timer" @onclick="CancelTimedPlayback">
+                                    Stops @localStopTime.ToString("t") · Cancel
+                                </button>
+                            }
                         </div>
                     </div>
+                    <dl class="stage-hero__stats" aria-label="Playback summary">
+                        <div>
+                            <dt>Volume</dt>
+                            <dd>@Volume%</dd>
+                        </div>
+                        <div>
+                            <dt>Rooms</dt>
+                            <dd>@_speakerStatuses.Count</dd>
+                        </div>
+                        <div>
+                            <dt>Queue</dt>
+                            <dd>@_queueTotalMatches</dd>
+                        </div>
+                    </dl>
                 </div>
-            }
+
+                @if (_settings.Speakers.Any())
+                {
+                    <div class="stage-hero__foot">
+                        <div class="stage-rooms" aria-label="Rooms">
+                            <span class="stage-foot-label" id="stage-rooms-label">Rooms</span>
+                            <div class="stage-rooms__chips" role="group" aria-labelledby="stage-rooms-label">
+                                @foreach (var speaker in _settings.Speakers)
+                                {
+                                    var isActiveRoom = string.Equals(SelectedSpeakerIp, speaker.IpAddress, StringComparison.OrdinalIgnoreCase);
+                                    <button type="button"
+                                            class="stage-room-chip @(isActiveRoom ? "is-active" : string.Empty)"
+                                            aria-pressed="@(isActiveRoom ? "true" : "false")"
+                                            @onclick="() => SelectedSpeakerIp = speaker.IpAddress">
+                                        <span class="stage-room-chip__dot" aria-hidden="true"></span>
+                                        @speaker.Name
+                                    </button>
+                                }
+                                <button type="button" class="stage-room-chip stage-room-chip--ghost" @onclick="OpenGroupModal" disabled="@(_isGrouping || _isUngrouping)" title="Group speakers">
+                                    @if (_isGrouping)
+                                    {
+                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                    }
+                                    else
+                                    {
+                                        <Icon Name="link" Size="13" />
+                                    }
+                                    <span>Group</span>
+                                </button>
+                                <button type="button" class="stage-room-chip stage-room-chip--ghost" @onclick="UngroupCurrent" disabled="@(_isGrouping || _isUngrouping)" title="Ungroup active speaker" aria-label="Ungroup active speaker">
+                                    @if (_isUngrouping)
+                                    {
+                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                    }
+                                    else
+                                    {
+                                        <Icon Name="unlink" Size="13" />
+                                    }
+                                    <span>Ungroup</span>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="stage-direct">
+                            <label class="stage-foot-label" for="homeDirectMediaUrl">Play a URL</label>
+                            <div class="stage-direct__row">
+                                <input id="homeDirectMediaUrl"
+                                       type="url"
+                                       class="form-control stage-direct__input"
+                                       @bind-value="_directMediaUrl"
+                                       @bind-value:event="oninput"
+                                       placeholder="https://..."
+                                       aria-label="Direct media URL" />
+                                <button type="button"
+                                        class="btn btn-primary stage-direct__play"
+                                        @onclick="PlayDirectMediaUrl"
+                                        disabled="@(_isDirectUrlLoading || string.IsNullOrWhiteSpace(_directMediaUrl))"
+                                        aria-label="Play direct URL">
+                                    @if (_isDirectUrlLoading)
+                                    {
+                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                    }
+                                    else
+                                    {
+                                        <Icon Name="play" Size="14" />
+                                    }
+                                </button>
+                                <button type="button"
+                                        class="btn btn-outline-primary stage-direct__save"
+                                        @onclick="OpenDirectUrlSaveModal"
+                                        disabled="@(_isDirectUrlLoading || string.IsNullOrWhiteSpace(_directMediaUrl))"
+                                        aria-label="Save direct URL">
+                                    <Icon Name="plus" Size="14" />
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </section>
 
             @if (!string.IsNullOrWhiteSpace(_commandStatusMessage))
             {
@@ -157,180 +211,25 @@
                 </div>
             }
 
-            <div class="home-ops-dashboard__grid">
-                <article class="home-ops-panel home-ops-panel--now">
-                    <div class="home-ops-panel__header">
-                        <h3><Icon Name="music" Size="17" /> Now Playing</h3>
-                        <span>@GetSelectedSpeakerName()</span>
-                    </div>
-                    <div class="home-ops-now">
-                        @if (!string.IsNullOrWhiteSpace(currentTrackArtUrl))
-                        {
-                            <img src="@currentTrackArtUrl" alt="@($"Album art for {currentlyPlaying}")" class="home-ops-now__art" />
-                        }
-                        else
-                        {
-                            <div class="home-ops-now__art home-ops-now__art--placeholder" aria-hidden="true">
-                                <Icon Name="music" Size="34" />
-                            </div>
-                        }
-                        <div class="home-ops-now__copy">
-                            <strong title="@currentlyPlaying">@currentlyPlaying</strong>
-                            <span title="@currentStationDisplay">@currentStationDisplay · @(_isPlaying ? "Playing" : "Paused")</span>
-                            <div class="home-ops-now__controls" aria-label="Playback quick controls">
-                                <button type="button" class="btn btn-sm btn-outline-secondary home-ops-icon-button" @onclick="HandleQueueRefresh" title="Refresh queue" aria-label="Refresh queue">
-                                    <Icon Name="refresh" Size="14" />
-                                </button>
-                                <button type="button" class="btn btn-sm btn-outline-secondary home-ops-icon-button" @onclick="NextTrack" disabled="@(!CanSkipToNextTrack() || _isNextTrackLoading)" title="Next track" aria-label="Next track">
-                                    <Icon Name="forward" Size="14" />
-                                </button>
-                                @if (_timerEndTimeUtc is not null)
-                                {
-                                    var localStopTime = _timerEndTimeUtc.Value.ToLocalTime();
-                                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="CancelTimedPlayback">
-                                        Cancel @localStopTime.ToString("t")
-                                    </button>
-                                }
-                            </div>
-                        </div>
-                    </div>
-                    <div class="home-ops-metrics">
-                        <div>
-                            <span>Volume</span>
-                            <strong>@Volume%</strong>
-                        </div>
-                        <div>
-                            <span>Rooms</span>
-                            <strong>@_speakerStatuses.Count</strong>
-                        </div>
-                        <div>
-                            <span>Queue</span>
-                            <strong>@_queueTotalMatches</strong>
-                        </div>
-                    </div>
-                </article>
-
-                <article class="home-ops-panel home-ops-panel--automation">
-                    <div class="home-ops-panel__header">
-                        <h3><Icon Name="schedule" Size="17" /> Active Automation</h3>
-                        <span>Schedule Windows</span>
-                    </div>
-                    <div class="home-ops-active-window">
-                        <div>
-                            <h4>@(activeWindow?.Name ?? "Manual control")</h4>
-                            <p>@GetActiveAutomationDescription(activeWindow, activeScene)</p>
-                            <div class="home-ops-chip-row">
-                                <span class="home-ops-chip">Priority @(activeWindow?.Priority.ToString() ?? "-")</span>
-                                <span class="home-ops-chip">Scene: @(activeScene?.Name ?? "None")</span>
-                                <span class="home-ops-chip">Fade out @(activeWindow?.FadeOutSeconds ?? 0)s</span>
-                                <span class="home-ops-chip">@GetSpeakerTargetSummary(activeScene)</span>
-                            </div>
-                        </div>
-                        <div class="home-ops-handoff">
-                            <strong>@GetAutomationHandoffLabel(activeWindow, nowLocal)</strong>
-                            <span>@(activeWindow is null ? "no active window" : "until handoff")</span>
-                        </div>
-                    </div>
-                    <div class="home-ops-timeline" aria-label="Upcoming schedule windows">
-                        @if (nextWindow is not null)
-                        {
-                            <div class="home-ops-timeline__row">
-                                <time>@nextWindow.StartTime.ToString("HH\\:mm")</time>
-                                <div>
-                                    <strong>@nextWindow.Name</strong>
-                                    <span>@GetSceneName(nextWindow.SceneId) · @GetWindowTimeRange(nextWindow)</span>
-                                </div>
-                                <span class="home-ops-timeline__state is-ready">Next</span>
-                            </div>
-                        }
-                        else
-                        {
-                            <div class="home-ops-empty-row">No next schedule window.</div>
-                        }
-                    </div>
-                </article>
-
-                <article class="home-ops-panel home-ops-panel--health">
-                    <div class="home-ops-panel__header">
-                        <h3><Icon Name="speaker" Size="17" /> Device Health</h3>
-                        <span>@(_settings.Speakers.Count) configured</span>
-                    </div>
-                    <div class="home-ops-health-grid">
-                        <div><span>Online</span><strong>@healthSummary.Online</strong></div>
-                        <div><span>Offline</span><strong>@healthSummary.Offline</strong></div>
-                        <div><span>Unknown</span><strong>@healthSummary.Unknown</strong></div>
-                    </div>
-                    <div class="home-ops-room-list">
-                        @foreach (var speaker in _settings.Speakers.OrderBy(s => s.Name).Take(5))
-                        {
-                            var status = healthSummary.ByIp.TryGetValue(speaker.IpAddress, out var value) ? value : null;
-                            <div class="home-ops-room">
-                                <span class="home-ops-room__dot @GetHealthClass(status)" aria-hidden="true"></span>
-                                <strong>@speaker.Name</strong>
-                                <span>@GetHealthMeta(status)</span>
-                            </div>
-                        }
-                        @if (_speakerStatuses.Any(s => s.GroupMembers.Any()))
-                        {
-                            @foreach (var root in _speakerStatuses.Where(s => s.GroupMembers.Any()).OrderBy(s => s.Name))
-                            {
-                                <div class="home-ops-room home-ops-room--group speaker-status-item">
-                                    <span class="home-ops-room__dot @(root.IsPlaying ? "is-online" : "is-unknown")" aria-hidden="true"></span>
-                                    <strong>@root.Name</strong>
-                                    <span>@($"Stereo/group: {string.Join(", ", root.GroupMembers)}")</span>
-                                    <span class="badge rounded-pill text-uppercase speaker-status-badge @(root.IsPlaying ? "text-bg-success" : "text-bg-secondary")">
-                                        @(root.IsPlaying ? "Playing" : "Paused")
-                                    </span>
-                                </div>
-                            }
-                        }
-                    </div>
-                </article>
-
-                <article class="home-ops-panel home-ops-panel--queue">
-                    <div class="home-ops-panel__header">
-                        <h3><Icon Name="list" Size="17" /> Up Next</h3>
-                        <span>@(_isQueueLoading ? "Loading" : !string.IsNullOrWhiteSpace(_queueErrorMessage) ? "Needs refresh" : _queueTotalMatches == 0 ? "Queue empty" : $"{_queueTotalMatches} items")</span>
-                    </div>
-                    <div class="home-ops-queue-list">
-                        @if (!string.IsNullOrWhiteSpace(_queueErrorMessage))
-                        {
-                            <div class="home-ops-empty-row">@_queueErrorMessage</div>
-                        }
-                        else if (_queueItems.Any())
-                        {
-                            @foreach (var item in _queueItems.Take(2))
-                            {
-                                var formatted = FormatQueueItem(item);
-                                <div class="home-ops-queue-row">
-                                    <strong title="@formatted">@formatted</strong>
-                                    <span>@(item.Index > 0 ? $"#{item.Index}" : "Queued")</span>
-                                </div>
-                            }
-                        }
-                        else
-                        {
-                            <div class="home-ops-empty-row">Queue is empty.</div>
-                        }
-                    </div>
-                </article>
-
-                <article class="home-ops-panel home-ops-panel--library">
+            <div class="stage-split">
+                <section class="stage-card stage-library" aria-label="Library">
                     @{
                         var toolbarYouTubeEntry = GetActiveToolbarYouTubeEntry();
                         var visibleYouTubeEntries = GetVisibleYouTubeEntries();
                     }
-                    <div class="home-ops-panel__header">
-                        <h3><Icon Name="star" Size="17" /> Library</h3>
-                        <span>All sources</span>
-                    </div>
-                    <div class="home-ops-library-tabs" role="tablist" aria-label="Media library">
+                    <header class="stage-card__header">
+                        <h3>Library</h3>
+                        <a class="stage-card__action" href="/recommendations">
+                            <Icon Name="settings" Size="13" /> Manage
+                        </a>
+                    </header>
+                    <div class="home-ops-library-tabs stage-segments" role="tablist" aria-label="Media library">
                         <button id="home-library-tab-stations" type="button" role="tab" class='@GetLibraryTabClass("stations")' aria-selected='@IsLibraryTabActive("stations").ToString().ToLowerInvariant()' @onclick='() => SetLibraryTab("stations")'>Stations</button>
                         <button id="home-library-tab-spotify" type="button" role="tab" class='@GetLibraryTabClass("spotify")' aria-selected='@IsLibraryTabActive("spotify").ToString().ToLowerInvariant()' @onclick='() => SetLibraryTab("spotify")'>Spotify</button>
                         <button id="home-library-tab-youtube" type="button" role="tab" class='@GetLibraryTabClass("youtube")' aria-selected='@IsLibraryTabActive("youtube").ToString().ToLowerInvariant()' @onclick='() => SetLibraryTab("youtube")'>YouTube</button>
-                        <button id="home-library-tab-youtube-music" type="button" role="tab" class='@GetLibraryTabClass("youtubemusic")' aria-selected='@IsLibraryTabActive("youtubemusic").ToString().ToLowerInvariant()' @onclick='() => SetLibraryTab("youtubemusic")'>YouTube Music</button>
+                        <button id="home-library-tab-youtube-music" type="button" role="tab" class='@GetLibraryTabClass("youtubemusic")' aria-selected='@IsLibraryTabActive("youtubemusic").ToString().ToLowerInvariant()' @onclick='() => SetLibraryTab("youtubemusic")'>YT Music</button>
                     </div>
-                    <div class="home-ops-library-search">
+                    <div class="home-ops-library-search stage-search">
                         <Icon Name="search" Size="14" />
                         <input type="search"
                                class="form-control form-control-sm"
@@ -339,71 +238,68 @@
                                placeholder="@GetLibrarySearchPlaceholder()"
                                aria-label="Search active library tab" />
                     </div>
-                    <div class="home-ops-source-toolbar">
-                        <button type="button" class="btn btn-sm btn-primary" @onclick="ShowAddStationModal" aria-label="Add Station">
-                            <Icon Name="plus" Size="14" /> Station
+                    <div class="stage-add-row" aria-label="Add to library">
+                        <button type="button" class="stage-add-chip" @onclick="ShowAddStationModal" aria-label="Add Station">
+                            <Icon Name="plus" Size="13" /> Station
                         </button>
-                        <button type="button" class="btn btn-sm btn-outline-primary" @onclick="ShowAddSpotifyModal" aria-label="Add Spotify Track">
-                            <Icon Name="plus" Size="14" /> Spotify
+                        <button type="button" class="stage-add-chip" @onclick="ShowAddSpotifyModal" aria-label="Add Spotify Track">
+                            <Icon Name="plus" Size="13" /> Spotify
                         </button>
-                        <button type="button" class="btn btn-sm btn-outline-primary" @onclick="ShowAddYouTubeModal" aria-label="Add YouTube Video">
-                            <Icon Name="plus" Size="14" /> YouTube
+                        <button type="button" class="stage-add-chip" @onclick="ShowAddYouTubeModal" aria-label="Add YouTube Video">
+                            <Icon Name="plus" Size="13" /> YouTube
                         </button>
-                        <button type="button" class="btn btn-sm btn-outline-primary" @onclick="ShowAddYouTubeMusicModal" aria-label="Add YouTube Music Collection">
-                            <Icon Name="plus" Size="14" /> YouTube Music
+                        <button type="button" class="stage-add-chip" @onclick="ShowAddYouTubeMusicModal" aria-label="Add YouTube Music Collection">
+                            <Icon Name="plus" Size="13" /> YT Music
                         </button>
-                        <a class="btn btn-sm btn-outline-secondary" href="/recommendations">
-                            <Icon Name="settings" Size="14" /> Manage
-                        </a>
-                        @if (toolbarYouTubeEntry is not null)
-                        {
-                            <div class="home-ops-youtube-toolbar" data-qa="home-youtube-mode-toolbar">
-                                <div class="home-ops-youtube-toolbar__header">
-                                    <label class="home-ops-youtube-toolbar__label" for="home-youtube-mode-entry">Mode</label>
-                                    <select id="home-youtube-mode-entry"
-                                            class="form-select form-select-sm"
-                                            value="@toolbarYouTubeEntry.Url"
-                                            aria-label="Select YouTube entry for playback mode"
-                                            @onchange="e => SetActiveYouTubeToolbarEntry(e.Value?.ToString())">
-                                        @foreach (var entry in visibleYouTubeEntries)
-                                        {
-                                            <option value="@entry.Url">@entry.Name</option>
-                                        }
-                                    </select>
-                                </div>
-                                <div class="home-ops-youtube-toolbar__modes" role="group" aria-label="YouTube playback mode">
-                                    <button type="button"
-                                            class="@GetYouTubeModeButtonClass(toolbarYouTubeEntry, YouTubePlaybackMode.AutoQueueRelated)"
-                                            aria-pressed="@IsYouTubeModeSelected(toolbarYouTubeEntry, YouTubePlaybackMode.AutoQueueRelated).ToString().ToLowerInvariant()"
-                                            @onclick="() => SetYouTubePlaybackModeAsync(toolbarYouTubeEntry, YouTubePlaybackMode.AutoQueueRelated.ToString())">
-                                        Auto Queue
-                                    </button>
-                                    <button type="button"
-                                            class="@GetYouTubeModeButtonClass(toolbarYouTubeEntry, YouTubePlaybackMode.Single)"
-                                            aria-pressed="@IsYouTubeModeSelected(toolbarYouTubeEntry, YouTubePlaybackMode.Single).ToString().ToLowerInvariant()"
-                                            @onclick="() => SetYouTubePlaybackModeAsync(toolbarYouTubeEntry, YouTubePlaybackMode.Single.ToString())">
-                                        Single
-                                    </button>
-                                    @if (YouTubePlaybackModeResolver.IsPlaylistLikeUrl(toolbarYouTubeEntry.Url))
-                                    {
-                                        <button type="button"
-                                                class="@GetYouTubeModeButtonClass(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistOrdered)"
-                                                aria-pressed="@IsYouTubeModeSelected(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistOrdered).ToString().ToLowerInvariant()"
-                                                @onclick="() => SetYouTubePlaybackModeAsync(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistOrdered.ToString())">
-                                            Ordered
-                                        </button>
-                                        <button type="button"
-                                                class="@GetYouTubeModeButtonClass(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistShuffle)"
-                                                aria-pressed="@IsYouTubeModeSelected(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistShuffle).ToString().ToLowerInvariant()"
-                                                @onclick="() => SetYouTubePlaybackModeAsync(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistShuffle.ToString())">
-                                            Shuffle
-                                        </button>
-                                    }
-                                </div>
-                            </div>
-                        }
                     </div>
-                    <div class="home-ops-library-list">
+                    @if (toolbarYouTubeEntry is not null)
+                    {
+                        <div class="home-ops-youtube-toolbar" data-qa="home-youtube-mode-toolbar">
+                            <div class="home-ops-youtube-toolbar__header">
+                                <label class="home-ops-youtube-toolbar__label" for="home-youtube-mode-entry">Mode</label>
+                                <select id="home-youtube-mode-entry"
+                                        class="form-select form-select-sm"
+                                        value="@toolbarYouTubeEntry.Url"
+                                        aria-label="Select YouTube entry for playback mode"
+                                        @onchange="e => SetActiveYouTubeToolbarEntry(e.Value?.ToString())">
+                                    @foreach (var entry in visibleYouTubeEntries)
+                                    {
+                                        <option value="@entry.Url">@entry.Name</option>
+                                    }
+                                </select>
+                            </div>
+                            <div class="home-ops-youtube-toolbar__modes" role="group" aria-label="YouTube playback mode">
+                                <button type="button"
+                                        class="@GetYouTubeModeButtonClass(toolbarYouTubeEntry, YouTubePlaybackMode.AutoQueueRelated)"
+                                        aria-pressed="@IsYouTubeModeSelected(toolbarYouTubeEntry, YouTubePlaybackMode.AutoQueueRelated).ToString().ToLowerInvariant()"
+                                        @onclick="() => SetYouTubePlaybackModeAsync(toolbarYouTubeEntry, YouTubePlaybackMode.AutoQueueRelated.ToString())">
+                                    Auto Queue
+                                </button>
+                                <button type="button"
+                                        class="@GetYouTubeModeButtonClass(toolbarYouTubeEntry, YouTubePlaybackMode.Single)"
+                                        aria-pressed="@IsYouTubeModeSelected(toolbarYouTubeEntry, YouTubePlaybackMode.Single).ToString().ToLowerInvariant()"
+                                        @onclick="() => SetYouTubePlaybackModeAsync(toolbarYouTubeEntry, YouTubePlaybackMode.Single.ToString())">
+                                    Single
+                                </button>
+                                @if (YouTubePlaybackModeResolver.IsPlaylistLikeUrl(toolbarYouTubeEntry.Url))
+                                {
+                                    <button type="button"
+                                            class="@GetYouTubeModeButtonClass(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistOrdered)"
+                                            aria-pressed="@IsYouTubeModeSelected(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistOrdered).ToString().ToLowerInvariant()"
+                                            @onclick="() => SetYouTubePlaybackModeAsync(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistOrdered.ToString())">
+                                        Ordered
+                                    </button>
+                                    <button type="button"
+                                            class="@GetYouTubeModeButtonClass(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistShuffle)"
+                                            aria-pressed="@IsYouTubeModeSelected(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistShuffle).ToString().ToLowerInvariant()"
+                                            @onclick="() => SetYouTubePlaybackModeAsync(toolbarYouTubeEntry, YouTubePlaybackMode.PlaylistShuffle.ToString())">
+                                        Shuffle
+                                    </button>
+                                }
+                            </div>
+                        </div>
+                    }
+                    <div class="home-ops-library-list stage-library__list">
                         @if (libraryItems.Any())
                         {
                             @foreach (var item in libraryItems)
@@ -451,13 +347,111 @@
                             <div class="home-ops-empty-row">@GetLibraryEmptyMessage()</div>
                         }
                     </div>
+                </section>
+
+                <aside class="stage-rail">
+                    <article class="stage-card" aria-label="Up next">
+                        <header class="stage-card__header">
+                            <h3>Up Next</h3>
+                            <span class="stage-card__hint">@(_isQueueLoading ? "Loading" : !string.IsNullOrWhiteSpace(_queueErrorMessage) ? "Needs refresh" : _queueTotalMatches == 0 ? "Queue empty" : $"{_queueTotalMatches} items")</span>
+                        </header>
+                        <div class="home-ops-queue-list">
+                            @if (!string.IsNullOrWhiteSpace(_queueErrorMessage))
+                            {
+                                <div class="home-ops-empty-row">@_queueErrorMessage</div>
+                            }
+                            else if (_queueItems.Any())
+                            {
+                                @foreach (var item in _queueItems.Take(3))
+                                {
+                                    var formatted = FormatQueueItem(item);
+                                    <div class="home-ops-queue-row">
+                                        <strong title="@formatted">@formatted</strong>
+                                        <span>@(item.Index > 0 ? $"#{item.Index}" : "Queued")</span>
+                                    </div>
+                                }
+                            }
+                            else
+                            {
+                                <div class="home-ops-empty-row">Queue is empty.</div>
+                            }
+                        </div>
+                    </article>
+
+                    <article class="stage-card" aria-label="Automation">
+                        <header class="stage-card__header">
+                            <h3>Automation</h3>
+                            <span class="stage-card__hint">@GetAutomationHandoffLabel(activeWindow, nowLocal) @(activeWindow is null ? string.Empty : "left")</span>
+                        </header>
+                        <div class="stage-automation">
+                            <h4>@(activeWindow?.Name ?? "Manual control")</h4>
+                            <p>@GetActiveAutomationDescription(activeWindow, activeScene)</p>
+                            <div class="home-ops-chip-row">
+                                <span class="home-ops-chip">Priority @(activeWindow?.Priority.ToString() ?? "-")</span>
+                                <span class="home-ops-chip">Scene: @(activeScene?.Name ?? "None")</span>
+                                <span class="home-ops-chip">Fade @(activeWindow?.FadeOutSeconds ?? 0)s</span>
+                                <span class="home-ops-chip">@GetSpeakerTargetSummary(activeScene)</span>
+                            </div>
+                        </div>
+                        <div class="home-ops-timeline" aria-label="Upcoming schedule windows">
+                            @if (nextWindow is not null)
+                            {
+                                <div class="home-ops-timeline__row">
+                                    <time>@nextWindow.StartTime.ToString("HH\\:mm")</time>
+                                    <div>
+                                        <strong>@nextWindow.Name</strong>
+                                        <span>@GetSceneName(nextWindow.SceneId) · @GetWindowTimeRange(nextWindow)</span>
+                                    </div>
+                                    <span class="home-ops-timeline__state is-ready">Next</span>
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="home-ops-empty-row">No next schedule window.</div>
+                            }
+                        </div>
+                    </article>
+                </aside>
+            </div>
+
+            <div class="stage-system">
+                <article class="stage-card" aria-label="Device health">
+                    <header class="stage-card__header">
+                        <h3>Devices</h3>
+                        <span class="stage-card__hint">@healthSummary.Online online · @healthSummary.Offline offline · @healthSummary.Unknown unknown</span>
+                    </header>
+                    <div class="home-ops-room-list">
+                        @foreach (var speaker in _settings.Speakers.OrderBy(s => s.Name).Take(5))
+                        {
+                            var status = healthSummary.ByIp.TryGetValue(speaker.IpAddress, out var value) ? value : null;
+                            <div class="home-ops-room">
+                                <span class="home-ops-room__dot @GetHealthClass(status)" aria-hidden="true"></span>
+                                <strong>@speaker.Name</strong>
+                                <span>@GetHealthMeta(status)</span>
+                            </div>
+                        }
+                        @if (_speakerStatuses.Any(s => s.GroupMembers.Any()))
+                        {
+                            @foreach (var root in _speakerStatuses.Where(s => s.GroupMembers.Any()).OrderBy(s => s.Name))
+                            {
+                                <div class="home-ops-room home-ops-room--group speaker-status-item">
+                                    <span class="home-ops-room__dot @(root.IsPlaying ? "is-online" : "is-unknown")" aria-hidden="true"></span>
+                                    <strong>@root.Name</strong>
+                                    <span>@($"Stereo/group: {string.Join(", ", root.GroupMembers)}")</span>
+                                    <span class="badge rounded-pill text-uppercase speaker-status-badge @(root.IsPlaying ? "text-bg-success" : "text-bg-secondary")">
+                                        @(root.IsPlaying ? "Playing" : "Paused")
+                                    </span>
+                                </div>
+                            }
+                        }
+                    </div>
                 </article>
 
-                <article class="home-ops-panel home-ops-panel--activity">
-                    <div class="home-ops-panel__header">
-                        <h3><Icon Name="file" Size="17" /> Recent Activity</h3>
-                        <span>Operational trail</span>
-                    </div>
+                <article class="stage-card" aria-label="Recent activity">
+                    <header class="stage-card__header">
+                        <h3>Activity</h3>
+                        <span class="stage-card__hint">Operational trail</span>
+                    </header>
                     <div class="home-ops-activity">
                         @if (recentActivity.Any())
                         {
@@ -478,13 +472,16 @@
                         }
                     </div>
                 </article>
-            </div>
 
-            <div class="home-ops-actions">
-                <a class="btn btn-primary" href="/scenes"><Icon Name="scenes" Size="15" /> Apply Scene</a>
-                <a class="btn btn-outline-primary" href="/devices"><Icon Name="search" Size="15" /> Discover Devices</a>
-                <a class="btn btn-outline-primary" href="/schedule-windows"><Icon Name="schedule" Size="15" /> Open Schedule</a>
-                <a class="btn btn-outline-secondary" href="/logs"><Icon Name="file" Size="15" /> View Logs</a>
+                <nav class="stage-card stage-shortcuts" aria-label="Shortcuts">
+                    <header class="stage-card__header">
+                        <h3>Shortcuts</h3>
+                    </header>
+                    <a class="stage-shortcut" href="/scenes"><Icon Name="scenes" Size="15" /> <span>Apply Scene</span><Icon Name="forward" Size="12" Class="stage-shortcut__chev" /></a>
+                    <a class="stage-shortcut" href="/devices"><Icon Name="search" Size="15" /> <span>Discover Devices</span><Icon Name="forward" Size="12" Class="stage-shortcut__chev" /></a>
+                    <a class="stage-shortcut" href="/schedule-windows"><Icon Name="schedule" Size="15" /> <span>Open Schedule</span><Icon Name="forward" Size="12" Class="stage-shortcut__chev" /></a>
+                    <a class="stage-shortcut" href="/logs"><Icon Name="file" Size="15" /> <span>View Logs</span><Icon Name="forward" Size="12" Class="stage-shortcut__chev" /></a>
+                </nav>
             </div>
         </section>
     </div>

--- a/SonosControl.Web/Shared/MainLayout.razor
+++ b/SonosControl.Web/Shared/MainLayout.razor
@@ -69,10 +69,6 @@
 
         <header class="app-top-bar">
             <div class="app-top-bar__content px-4">
-                <div class="app-top-bar__identity">
-                    <span class="app-top-bar__title">SonosControl</span>
-                    <span class="app-top-bar__subtitle">Master every room</span>
-                </div>
                 <div class="top-bar-actions">
                     @if (isAuthenticated)
                     {

--- a/SonosControl.Web/Shared/NavMenu.razor
+++ b/SonosControl.Web/Shared/NavMenu.razor
@@ -27,6 +27,7 @@
 
     <div class="nav-scrollable px-3" data-drawer-open="@(IsDrawerOpen ? "true" : "false")">
         <nav class="nav-links">
+            <span class="nav-section-label">Listen</span>
             <div class="nav-item">
                 <NavLink class="nav-link" href="" Match="NavLinkMatch.All" @onclick="HandleNavigate">
                     <Icon Name="home" Size="16" Class="nav-icon" />
@@ -42,6 +43,7 @@
 
             <AuthorizeView Roles="admin,operator,superadmin">
                 <Authorized>
+                    <span class="nav-section-label">Insights</span>
                     <div class="nav-item">
                         <NavLink class="nav-link" href="stats" @onclick="HandleNavigate">
                             <Icon Name="graph" Size="16" Class="nav-icon" />
@@ -65,7 +67,7 @@
 
             <AuthorizeView Roles="admin,superadmin">
                 <Authorized>
-                    <div class="nav-divider" aria-hidden="true"></div>
+                    <span class="nav-section-label">Manage</span>
                     <div class="nav-item">
                         <NavLink class="nav-link" href="schedule-windows" @onclick="HandleNavigate">
                             <Icon Name="calendar" Size="16" Class="nav-icon" />

--- a/SonosControl.Web/wwwroot/css/site.css
+++ b/SonosControl.Web/wwwroot/css/site.css
@@ -4670,3 +4670,736 @@ h1, h2, h3, h4, h5, h6 {
         scroll-behavior: auto;
     }
 }
+
+/* ============================================================
+   STAGE — redesigned home: hero player, library, side rail
+   ============================================================ */
+
+.stage-shell {
+    width: 100%;
+    max-width: 90rem;
+    margin-inline: auto;
+    min-width: 0;
+}
+
+.home-ops-dashboard.stage {
+    border: 0;
+    border-radius: 0;
+    background: none;
+    box-shadow: none;
+    overflow: visible;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.1rem, 1.6vw, 1.6rem);
+}
+
+@keyframes stage-rise {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: none; }
+}
+
+.stage > * {
+    animation: stage-rise 480ms cubic-bezier(0.22, 1, 0.36, 1) backwards;
+}
+
+.stage > *:nth-child(2) { animation-delay: 40ms; }
+.stage > *:nth-child(3) { animation-delay: 90ms; }
+.stage > *:nth-child(4) { animation-delay: 140ms; }
+.stage > *:nth-child(5) { animation-delay: 190ms; }
+
+/* --- Masthead ------------------------------------------------ */
+.stage-masthead {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    padding-top: 0.5rem;
+}
+
+.stage-masthead h1 {
+    margin: 0;
+    font-size: clamp(1.9rem, 2.6vw, 2.7rem);
+    letter-spacing: -0.03em;
+    background: linear-gradient(100deg, var(--text-primary) 35%, color-mix(in srgb, var(--brand-primary) 85%, var(--text-primary)) 80%, var(--brand-accent) 110%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.stage-eyebrow {
+    display: inline-block;
+    margin-bottom: 0.3rem;
+    font-size: 0.74rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--brand-primary) 80%, var(--text-muted));
+}
+
+.stage-masthead__meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.4rem;
+}
+
+.stage-masthead__meta small {
+    color: var(--text-muted);
+    font-size: 0.76rem;
+}
+
+/* --- Hero: now playing stage --------------------------------- */
+.stage-hero {
+    position: relative;
+    border-radius: var(--radius-2xl);
+    border: 1px solid color-mix(in srgb, var(--border-subtle) 85%, transparent);
+    background: color-mix(in srgb, var(--surface-1) 78%, transparent);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    padding: clamp(1.25rem, 2.2vw, 2rem);
+    overflow: hidden;
+}
+
+[data-theme='dark'] .stage-hero {
+    border-color: color-mix(in srgb, var(--border-strong) 60%, transparent);
+    background: color-mix(in srgb, var(--surface-1) 72%, transparent);
+}
+
+.stage-hero__backdrop {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(38rem 20rem at 8% -30%, color-mix(in srgb, var(--brand-primary) 16%, transparent) 0%, transparent 58%),
+        radial-gradient(30rem 18rem at 95% -20%, color-mix(in srgb, var(--brand-accent) 11%, transparent) 0%, transparent 55%);
+}
+
+.stage-hero__main {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: clamp(1.1rem, 2vw, 1.9rem);
+}
+
+.stage-hero__art,
+.home-ops-now__art.stage-hero__art {
+    width: clamp(108px, 12vw, 148px);
+    height: clamp(108px, 12vw, 148px);
+    border-radius: var(--radius-xl);
+    object-fit: cover;
+    box-shadow: 0 18px 44px color-mix(in srgb, var(--brand-primary) 26%, rgba(0, 0, 0, 0.25)), 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.stage-hero__meta {
+    min-width: 0;
+}
+
+.stage-hero__context {
+    display: block;
+    font-size: 0.74rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.stage-hero__title {
+    margin: 0.35rem 0 0;
+    font-size: clamp(1.45rem, 2.4vw, 2.3rem);
+    line-height: 1.08;
+    letter-spacing: -0.025em;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.stage-hero__station {
+    margin: 0.3rem 0 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.stage-transport {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    margin-top: 1.05rem;
+}
+
+.stage-transport__button,
+.stage-transport__play {
+    display: inline-grid;
+    place-items: center;
+    border-radius: 50%;
+    border: 0;
+    transition: transform 180ms cubic-bezier(0.22, 1, 0.36, 1), background-color 160ms ease, color 160ms ease, box-shadow 180ms ease;
+}
+
+.stage-transport__button {
+    width: 2.6rem;
+    height: 2.6rem;
+    color: var(--text-secondary);
+    background: color-mix(in srgb, var(--surface-2) 75%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border-subtle) 80%, transparent);
+}
+
+.stage-transport__button:hover:not(:disabled) {
+    color: var(--text-primary);
+    background: var(--surface-3);
+    transform: translateY(-1px);
+}
+
+.stage-transport__button:active:not(:disabled) {
+    transform: scale(0.94);
+}
+
+.stage-transport__button:disabled {
+    opacity: 0.4;
+}
+
+.stage-transport__play {
+    width: 3.5rem;
+    height: 3.5rem;
+    color: #03130a;
+    background: var(--gradient-primary);
+    box-shadow: 0 12px 30px color-mix(in srgb, var(--brand-primary) 38%, transparent), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.stage-transport__play:hover:not(:disabled) {
+    transform: scale(1.06);
+    filter: brightness(1.08);
+}
+
+.stage-transport__play:active:not(:disabled) {
+    transform: scale(0.96);
+}
+
+.stage-transport__divider {
+    width: 1px;
+    height: 1.6rem;
+    background: color-mix(in srgb, var(--border-strong) 70%, transparent);
+    margin-inline: 0.2rem;
+}
+
+.stage-transport__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 2.25rem;
+    padding: 0.35rem 0.9rem;
+    border-radius: var(--radius-pill);
+    border: 1px solid color-mix(in srgb, var(--border-subtle) 85%, transparent);
+    background: color-mix(in srgb, var(--surface-2) 65%, transparent);
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+    font-weight: 700;
+    transition: background-color 160ms ease, color 160ms ease, border-color 160ms ease, transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.stage-transport__chip:hover:not(:disabled) {
+    color: var(--text-primary);
+    border-color: color-mix(in srgb, var(--brand-primary) 40%, var(--border-subtle));
+    background: color-mix(in srgb, var(--brand-primary) 10%, transparent);
+    transform: translateY(-1px);
+}
+
+.stage-transport__chip:disabled {
+    opacity: 0.5;
+}
+
+.stage-transport__chip--timer {
+    color: color-mix(in srgb, var(--brand-warning) 75%, var(--text-primary));
+    border-color: color-mix(in srgb, var(--brand-warning) 38%, transparent);
+    background: color-mix(in srgb, var(--brand-warning) 10%, transparent);
+}
+
+.stage-hero__stats {
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    margin: 0;
+    padding-left: clamp(1rem, 2vw, 1.75rem);
+    border-left: 1px solid color-mix(in srgb, var(--border-subtle) 75%, transparent);
+}
+
+.stage-hero__stats div {
+    text-align: right;
+}
+
+.stage-hero__stats dt {
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.stage-hero__stats dd {
+    margin: 0.1rem 0 0;
+    font-family: var(--font-family-display);
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+}
+
+.stage-hero__foot {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1.7fr) minmax(16rem, 1fr);
+    gap: clamp(1rem, 2vw, 1.75rem);
+    margin-top: clamp(1rem, 1.8vw, 1.5rem);
+    padding-top: clamp(0.9rem, 1.6vw, 1.25rem);
+    border-top: 1px solid color-mix(in srgb, var(--border-subtle) 70%, transparent);
+}
+
+.stage-foot-label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.stage-rooms__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+}
+
+.stage-room-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    min-height: 2.15rem;
+    padding: 0.3rem 0.85rem;
+    border-radius: var(--radius-pill);
+    border: 1px solid color-mix(in srgb, var(--border-subtle) 85%, transparent);
+    background: color-mix(in srgb, var(--surface-2) 60%, transparent);
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+    font-weight: 700;
+    transition: background-color 160ms ease, color 160ms ease, border-color 160ms ease, transform 180ms cubic-bezier(0.22, 1, 0.36, 1), box-shadow 180ms ease;
+}
+
+.stage-room-chip__dot {
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 50%;
+    background: var(--text-muted);
+    transition: background-color 160ms ease, box-shadow 160ms ease;
+}
+
+.stage-room-chip:hover:not(:disabled) {
+    color: var(--text-primary);
+    border-color: color-mix(in srgb, var(--brand-primary) 35%, var(--border-subtle));
+    transform: translateY(-1px);
+}
+
+.stage-room-chip:active:not(:disabled) {
+    transform: scale(0.97);
+}
+
+.stage-room-chip.is-active {
+    color: #03130a;
+    background: var(--gradient-primary);
+    border-color: transparent;
+    box-shadow: 0 8px 22px color-mix(in srgb, var(--brand-primary) 32%, transparent);
+}
+
+.stage-room-chip.is-active .stage-room-chip__dot {
+    background: #03130a;
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.25);
+}
+
+.stage-room-chip--ghost {
+    background: transparent;
+    border-style: dashed;
+    border-color: color-mix(in srgb, var(--border-strong) 75%, transparent);
+}
+
+.stage-room-chip:disabled {
+    opacity: 0.5;
+}
+
+.stage-direct__row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    gap: 0.45rem;
+    align-items: center;
+}
+
+.stage-direct__input {
+    border-radius: var(--radius-pill);
+    padding-inline: 1rem;
+}
+
+.stage-direct__play,
+.stage-direct__save {
+    display: inline-grid;
+    place-items: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    border-radius: 50%;
+}
+
+/* --- Split: library + rail ------------------------------------ */
+.stage-split {
+    display: grid;
+    grid-template-columns: minmax(0, 1.55fr) minmax(19rem, 1fr);
+    gap: clamp(1rem, 1.6vw, 1.5rem);
+    align-items: start;
+    min-width: 0;
+}
+
+.stage-rail {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 1.6vw, 1.5rem);
+    min-width: 0;
+}
+
+.stage-card {
+    min-width: 0;
+    border-radius: var(--radius-xl);
+    border: 1px solid color-mix(in srgb, var(--border-subtle) 85%, transparent);
+    background: color-mix(in srgb, var(--surface-1) 78%, transparent);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    padding: 1.15rem 1.2rem 1.25rem;
+    transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.stage-card:hover {
+    border-color: color-mix(in srgb, var(--brand-primary) 22%, var(--border-subtle));
+    box-shadow: 0 12px 36px color-mix(in srgb, var(--brand-primary) 8%, rgba(0, 0, 0, 0.06));
+}
+
+[data-theme='dark'] .stage-card {
+    border-color: color-mix(in srgb, var(--border-strong) 55%, transparent);
+    background: color-mix(in srgb, var(--surface-1) 74%, transparent);
+}
+
+.stage-card__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+    margin-bottom: 0.95rem;
+}
+
+.stage-card__header h3 {
+    margin: 0;
+    font-size: 1.02rem;
+    letter-spacing: -0.01em;
+}
+
+.stage-card__hint {
+    color: var(--text-muted);
+    font-size: 0.76rem;
+    text-align: right;
+}
+
+.stage-card__action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.28rem 0.75rem;
+    border-radius: var(--radius-pill);
+    border: 1px solid color-mix(in srgb, var(--border-subtle) 85%, transparent);
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-decoration: none;
+    transition: color 160ms ease, border-color 160ms ease, background-color 160ms ease;
+}
+
+.stage-card__action:hover {
+    color: var(--text-primary);
+    border-color: color-mix(in srgb, var(--brand-primary) 40%, var(--border-subtle));
+    background: color-mix(in srgb, var(--brand-primary) 9%, transparent);
+}
+
+/* Library: segmented control + search + list */
+.home-ops-library-tabs.stage-segments {
+    display: flex;
+    gap: 0.25rem;
+    padding: 0.28rem;
+    margin-bottom: 0.8rem;
+    border-radius: var(--radius-pill);
+    border: 1px solid color-mix(in srgb, var(--border-subtle) 80%, transparent);
+    background: color-mix(in srgb, var(--surface-2) 65%, transparent);
+}
+
+.stage-segments .home-ops-library-tab {
+    flex: 1 1 0;
+    min-height: 2.05rem;
+    border: 0;
+    border-radius: var(--radius-pill);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 700;
+    transition: background-color 180ms ease, color 180ms ease, box-shadow 180ms ease;
+}
+
+.stage-segments .home-ops-library-tab:hover {
+    color: var(--text-primary);
+}
+
+.stage-segments .home-ops-library-tab.is-active {
+    color: #03130a;
+    background: var(--gradient-primary);
+    box-shadow: 0 4px 14px color-mix(in srgb, var(--brand-primary) 30%, transparent);
+}
+
+.stage-search {
+    margin-bottom: 0.8rem;
+}
+
+.stage-search .form-control {
+    border-radius: var(--radius-pill);
+    padding-left: 2.1rem;
+    background-color: color-mix(in srgb, var(--surface-2) 60%, transparent);
+}
+
+.stage-add-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-bottom: 0.9rem;
+}
+
+.stage-add-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 1.95rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: var(--radius-pill);
+    border: 1px dashed color-mix(in srgb, var(--border-strong) 80%, transparent);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    font-weight: 700;
+    transition: color 160ms ease, border-color 160ms ease, background-color 160ms ease;
+}
+
+.stage-add-chip:hover {
+    color: color-mix(in srgb, var(--brand-primary) 80%, var(--text-primary));
+    border-color: color-mix(in srgb, var(--brand-primary) 50%, transparent);
+    border-style: solid;
+    background: color-mix(in srgb, var(--brand-primary) 8%, transparent);
+}
+
+.stage-library__list {
+    max-height: 29rem;
+    overflow-y: auto;
+    padding-right: 0.2rem;
+}
+
+.stage-library .home-ops-library-item {
+    background: transparent;
+    border-radius: var(--radius-md);
+    padding: 0.6rem 0.55rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 55%, transparent);
+    transition: background-color 160ms ease;
+}
+
+.stage-library .home-ops-library-item:last-child {
+    border-bottom: 0;
+}
+
+.stage-library .home-ops-library-item:hover {
+    background: color-mix(in srgb, var(--surface-2) 70%, transparent);
+}
+
+@media (hover: hover) {
+    .stage-library .home-ops-mini-play {
+        opacity: 0;
+        transform: scale(0.9);
+        transition: opacity 160ms ease, transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    .stage-library .home-ops-library-item:hover .home-ops-mini-play,
+    .stage-library .home-ops-library-item:focus-within .home-ops-mini-play {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+/* Automation card */
+.stage-automation h4 {
+    margin: 0;
+    font-size: 1.05rem;
+}
+
+.stage-automation p {
+    margin: 0.35rem 0 0;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    line-height: 1.5;
+}
+
+.stage-automation .home-ops-chip-row {
+    margin-top: 0.7rem;
+}
+
+.stage-card .home-ops-timeline {
+    margin-top: 0.85rem;
+}
+
+/* --- System strip --------------------------------------------- */
+.stage-system {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1.2fr) minmax(15rem, 0.9fr);
+    gap: clamp(1rem, 1.6vw, 1.5rem);
+    align-items: start;
+    min-width: 0;
+}
+
+.stage-shortcuts {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 0.6rem;
+}
+
+.stage-shortcut {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.62rem 0.35rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 55%, transparent);
+    color: var(--text-secondary);
+    font-size: 0.86rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: color 160ms ease, transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.stage-shortcut:last-child {
+    border-bottom: 0;
+}
+
+.stage-shortcut:hover {
+    color: var(--text-primary);
+    transform: translateX(3px);
+}
+
+.stage-shortcut__chev {
+    color: var(--text-muted);
+}
+
+/* --- Nav section labels ---------------------------------------- */
+.nav-section-label {
+    display: block;
+    margin: 0.9rem 0.95rem 0.35rem;
+    font-size: 0.66rem;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.nav-links .nav-section-label:first-child {
+    margin-top: 0;
+}
+
+/* --- Slim top bar ----------------------------------------------- */
+.app-top-bar__content {
+    min-height: 60px;
+    justify-content: flex-end;
+}
+
+/* --- Responsive ------------------------------------------------- */
+@media (max-width: 1099.98px) {
+    .stage-split,
+    .stage-system {
+        grid-template-columns: 1fr;
+    }
+
+    .stage-library__list {
+        max-height: 24rem;
+    }
+}
+
+@media (max-width: 819.98px) {
+    .stage-hero__main {
+        grid-template-columns: auto minmax(0, 1fr);
+    }
+
+    .stage-hero__stats {
+        grid-column: 1 / -1;
+        flex-direction: row;
+        justify-content: space-between;
+        gap: 0.5rem;
+        margin-top: 0.4rem;
+        padding-left: 0;
+        padding-top: 0.85rem;
+        border-left: 0;
+        border-top: 1px solid color-mix(in srgb, var(--border-subtle) 70%, transparent);
+    }
+
+    .stage-hero__stats div {
+        text-align: left;
+    }
+
+    .stage-hero__foot {
+        grid-template-columns: 1fr;
+    }
+
+    .stage-masthead {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+
+    .stage-masthead__meta {
+        flex-direction: row;
+        align-items: center;
+        gap: 0.7rem;
+    }
+}
+
+@media (max-width: 539.98px) {
+    .stage-hero__main {
+        grid-template-columns: 1fr;
+    }
+
+    .stage-hero__art,
+    .home-ops-now__art.stage-hero__art {
+        width: 96px;
+        height: 96px;
+    }
+
+    .stage-direct__row {
+        grid-template-columns: minmax(0, 1fr) auto auto;
+    }
+
+    .stage-segments .home-ops-library-tab {
+        font-size: 0.72rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .stage > * {
+        animation: none;
+    }
+
+    .stage-transport__play,
+    .stage-transport__button,
+    .stage-room-chip,
+    .stage-shortcut {
+        transition: none;
+    }
+}


### PR DESCRIPTION
Rethinks the dashboard's information architecture as a music player rather than an ops console:

- Hero now-playing stage: large artwork with ambient backdrop, display-type track title, circular transport controls with a gradient play button, and inline volume/rooms/queue stats
- Room selection becomes tappable pill chips (replacing the select), with group/ungroup actions and the direct-URL row in the hero footer
- Library promoted to primary content with an iOS-style segmented control, pill search, dashed add-chips, and hover-revealed play buttons on rows
- Up Next and Automation move to a compact side rail; device health, activity, and shortcuts demoted to a quiet system strip
- Staggered entrance animations and spring micro-interactions, disabled under prefers-reduced-motion
- Sidebar nav grouped under Listen / Insights / Manage section labels; desktop top bar slimmed to a utility bar (brand lives in sidebar)

All Blazor bindings and test selectors (#home-library-tab-*, data-qa hooks, home-ops-* class hooks, aria-labels) are preserved.

## Summary of change

Describe what changed and why.

## Related issue(s)

Closes #
Related #

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test improvement

## Validation performed

- [ ] `dotnet test`
- [ ] Relevant smoke test(s) for changed behavior
- [ ] Docs/markdown checks (if docs changed)

Add command output snippets or short evidence notes:

```text
Paste verification notes here
```

## UI changes (if applicable)

- [ ] UI was changed in this PR
- [ ] I added or updated screenshots/GIFs

## Docs and maintenance

- [ ] I updated docs/README/CONTRIBUTING when behavior or workflows changed
- [ ] No docs updates were needed for this change
